### PR TITLE
Allow "requires" blocks in structs.

### DIFF
--- a/antlr-parser/src/main/antlr/sem1/antlr/Sem1Lexer.g4
+++ b/antlr-parser/src/main/antlr/sem1/antlr/Sem1Lexer.g4
@@ -22,6 +22,7 @@ RETURN             : 'return';
 LET                : 'let';
 IF                 : 'if';
 ELSE               : 'else';
+REQUIRES           : 'requires';
 
 // Literals
 LITERAL            : '"' ( ~["\\] | '\\' . )* '"' ;

--- a/antlr-parser/src/main/antlr/sem1/antlr/Sem1Parser.g4
+++ b/antlr-parser/src/main/antlr/sem1/antlr/Sem1Parser.g4
@@ -18,6 +18,7 @@ tokens {
   LET,
   IF,
   ELSE,
+  REQUIRES,
   LITERAL,
   DOT,
   COMMA,
@@ -54,10 +55,11 @@ block : LBRACE assignments return_statement RBRACE ;
 function_arguments : | function_argument | function_argument COMMA function_arguments ;
 function_argument : ID COLON type ;
 
-struct : annotations STRUCT function_id LBRACE struct_components RBRACE
-  | annotations STRUCT function_id LESS_THAN cd_ids GREATER_THAN LBRACE struct_components RBRACE ;
-struct_components : | struct_component struct_components ;
-struct_component : ID COLON type ;
+struct : annotations STRUCT function_id LBRACE struct_members maybe_requires RBRACE
+  | annotations STRUCT function_id LESS_THAN cd_ids GREATER_THAN LBRACE struct_members maybe_requires RBRACE ;
+struct_members : | struct_member struct_members ;
+struct_member : ID COLON type ;
+maybe_requires : | REQUIRES block ;
 
 // TODO: Is there a better solution for this than mangling the name?
 interfac : annotations INTERFACE function_id LBRACE methods RBRACE

--- a/java-compiled-runtime/src/main/java/net/semlang/java/Naturals.java
+++ b/java-compiled-runtime/src/main/java/net/semlang/java/Naturals.java
@@ -7,6 +7,10 @@ public class Naturals {
         // Not instantiable
     }
 
+    public static boolean greaterThan(BigInteger left, BigInteger right) {
+        return left.compareTo(right) > 0;
+    }
+
     public static BigInteger absoluteDifference(BigInteger left, BigInteger right) {
         return left.subtract(right).abs();
     }

--- a/java-compiled-runtime/src/main/java/net/semlang/java/Tries.java
+++ b/java-compiled-runtime/src/main/java/net/semlang/java/Tries.java
@@ -8,6 +8,10 @@ public class Tries {
         // Not instantiable
     }
 
+    public static <T> Optional<T> failure() {
+        return Optional.empty();
+    }
+
     public static <T> T assume(Optional<T> argument) {
         return argument.get();
     }

--- a/java-compiled-runtime/src/main/java/net/semlang/java/UnicodeStrings.java
+++ b/java-compiled-runtime/src/main/java/net/semlang/java/UnicodeStrings.java
@@ -2,6 +2,7 @@ package net.semlang.java;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class UnicodeStrings {
@@ -16,5 +17,14 @@ public class UnicodeStrings {
 
     public static List<Integer> toCodePoints(String string) {
         return string.codePoints().boxed().collect(Collectors.toList());
+    }
+
+    private static final BigInteger UPPER_CODE_POINT_BOUND_EXCLUSIVE = BigInteger.valueOf(1_114_112L);
+    public static Optional<Integer> asCodePoint(BigInteger value) {
+        if (UPPER_CODE_POINT_BOUND_EXCLUSIVE.compareTo(value) > 0) {
+            return Optional.of(value.intValueExact());
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/kotlin-api/src/main/kotlin/context.kt
+++ b/kotlin-api/src/main/kotlin/context.kt
@@ -2,9 +2,6 @@ package semlang.api
 
 import java.util.HashMap
 
-//TODO: Validate inputs (non-overlapping keys)
-//TODO: Rename to UnvalidatedContext?
-//data class InterpreterContext(val functions: Map<FunctionId, Function>, val structs: Map<FunctionId, UnvalidatedStruct>, val interfaces: Map<FunctionId, Interface>)
 data class RawContext(val functions: List<Function>, val structs: List<UnvalidatedStruct>, val interfaces: List<Interface>)
 
 // TODO: We'll want this to be able to reference upstream contexts without repeating their contents

--- a/kotlin-api/src/main/kotlin/context.kt
+++ b/kotlin-api/src/main/kotlin/context.kt
@@ -4,7 +4,8 @@ import java.util.HashMap
 
 //TODO: Validate inputs (non-overlapping keys)
 //TODO: Rename to UnvalidatedContext?
-data class InterpreterContext(val functions: Map<FunctionId, Function>, val structs: Map<FunctionId, Struct>, val interfaces: Map<FunctionId, Interface>)
+//data class InterpreterContext(val functions: Map<FunctionId, Function>, val structs: Map<FunctionId, UnvalidatedStruct>, val interfaces: Map<FunctionId, Interface>)
+data class RawContext(val functions: List<Function>, val structs: List<UnvalidatedStruct>, val interfaces: List<Interface>)
 
 // TODO: We'll want this to be able to reference upstream contexts without repeating their contents
 class ValidatedContext private constructor(val ownFunctionImplementations: Map<FunctionId, ValidatedFunction>,

--- a/kotlin-api/src/main/kotlin/language.kt
+++ b/kotlin-api/src/main/kotlin/language.kt
@@ -218,8 +218,15 @@ data class ValidatedFunction(val id: FunctionId, val typeParameters: List<String
 }
 
 data class UnvalidatedStruct(override val id: FunctionId, val typeParameters: List<String>, val members: List<Member>, val requires: Block?, val annotations: List<Annotation>) : HasFunctionId {
-    fun getIndexForName(name: String): Int {
-        return members.indexOfFirst { member -> member.name == name }
+    fun getConstructorSignature(): TypeSignature {
+        val argumentTypes = members.map(Member::type)
+        val typeParameters = typeParameters.map(Type.NamedType.Companion::forParameter)
+        val outputType = if (requires == null) {
+            Type.NamedType(id, typeParameters)
+        } else {
+            Type.Try(Type.NamedType(id, typeParameters))
+        }
+        return TypeSignature(id, argumentTypes, outputType, typeParameters)
     }
 }
 data class Struct(override val id: FunctionId, val typeParameters: List<String>, val members: List<Member>, val requires: TypedBlock?, val annotations: List<Annotation>) : HasFunctionId {

--- a/kotlin-api/src/main/kotlin/language.kt
+++ b/kotlin-api/src/main/kotlin/language.kt
@@ -233,6 +233,18 @@ data class Struct(override val id: FunctionId, val typeParameters: List<String>,
     fun getIndexForName(name: String): Int {
         return members.indexOfFirst { member -> member.name == name }
     }
+
+    // TODO: Deconflict with UnvalidatedStruct version
+    fun getConstructorSignature(): TypeSignature {
+        val argumentTypes = members.map(Member::type)
+        val typeParameters = typeParameters.map(Type.NamedType.Companion::forParameter)
+        val outputType = if (requires == null) {
+            Type.NamedType(id, typeParameters)
+        } else {
+            Type.Try(Type.NamedType(id, typeParameters))
+        }
+        return TypeSignature(id, argumentTypes, outputType, typeParameters)
+    }
 }
 interface HasFunctionId {
     val id: FunctionId

--- a/kotlin-api/src/main/kotlin/language.kt
+++ b/kotlin-api/src/main/kotlin/language.kt
@@ -217,7 +217,12 @@ data class ValidatedFunction(val id: FunctionId, val typeParameters: List<String
     }
 }
 
-data class Struct(override val id: FunctionId, val typeParameters: List<String>, val members: List<Member>, val annotations: List<Annotation>) : HasFunctionId {
+data class UnvalidatedStruct(override val id: FunctionId, val typeParameters: List<String>, val members: List<Member>, val requires: Block?, val annotations: List<Annotation>) : HasFunctionId {
+    fun getIndexForName(name: String): Int {
+        return members.indexOfFirst { member -> member.name == name }
+    }
+}
+data class Struct(override val id: FunctionId, val typeParameters: List<String>, val members: List<Member>, val requires: TypedBlock?, val annotations: List<Annotation>) : HasFunctionId {
     fun getIndexForName(name: String): Int {
         return members.indexOfFirst { member -> member.name == name }
     }
@@ -232,7 +237,7 @@ data class Interface(override val id: FunctionId, val typeParameters: List<Strin
         return methods.indexOfFirst { method -> method.name == name }
     }
     val adapterId: FunctionId = FunctionId(id.toPackage(), "Adapter")
-    val adapterStruct: Struct = Struct(adapterId, typeParameters, methods.map { method -> Member(method.name, method.functionType) }, listOf())
+    val adapterStruct: Struct = Struct(adapterId, typeParameters, methods.map { method -> Member(method.name, method.functionType) }, null, listOf())
 }
 data class Method(val name: String, val typeParameters: List<String>, val arguments: List<Argument>, val returnType: Type) {
     val functionType = Type.FunctionType(arguments.map { arg -> arg.type }, returnType)

--- a/kotlin-api/src/main/kotlin/nativeFunctions.kt
+++ b/kotlin-api/src/main/kotlin/nativeFunctions.kt
@@ -161,6 +161,8 @@ private fun addNaturalFunctions(definitions: ArrayList<TypeSignature>) {
 
     // Natural.equals
     definitions.add(TypeSignature(FunctionId(naturalPackage, "equals"), listOf(Type.NATURAL, Type.NATURAL), Type.BOOLEAN))
+    // Natural.greaterThan
+    definitions.add(TypeSignature(FunctionId(naturalPackage, "greaterThan"), listOf(Type.NATURAL, Type.NATURAL), Type.BOOLEAN))
 
     // TODO: Resolve these conflicting definitions
     // Natural.max
@@ -238,6 +240,11 @@ private fun addTryFunctions(definitions: ArrayList<TypeSignature>) {
     val paramT = Type.NamedType.forParameter("T")
     val paramU = Type.NamedType.forParameter("U")
 
+    // Try.failure
+    definitions.add(TypeSignature(FunctionId(tryPackage, "failure"), typeParameters = listOf(paramT),
+            argumentTypes = listOf(),
+            outputType = Type.Try(paramT)))
+
     // Try.assume
     definitions.add(TypeSignature(FunctionId(tryPackage, "assume"), typeParameters = listOf(paramT),
             argumentTypes = listOf(Type.Try(paramT)),
@@ -287,6 +294,7 @@ object NativeStruct {
                     Member("base", typeT),
                     Member("successor", Type.FunctionType(listOf(typeT), typeT))
             ),
+            null,
             listOf()
     )
     private val UNICODE_PACKAGE = Package(listOf("Unicode"))
@@ -297,6 +305,7 @@ object NativeStruct {
                     // TODO: Restrict to the maximum possible code point value
                     Member("value", Type.NATURAL)
             ),
+            null, // TODO: Add the actual restriction here, and test
             listOf()
     )
     val UNICODE_STRING = Struct(
@@ -305,6 +314,7 @@ object NativeStruct {
             listOf(
                     Member("value", Type.List(Type.NamedType(UNICODE_CODE_POINT.id)))
             ),
+            null,
             listOf()
     )
 }

--- a/kotlin-interpreter/src/main/kotlin/NativeFunctions.kt
+++ b/kotlin-interpreter/src/main/kotlin/NativeFunctions.kt
@@ -142,6 +142,13 @@ private fun addNaturalFunctions(list: MutableList<NativeFunction>) {
         SemObject.Boolean(left.value == right.value)
     }))
 
+    // Natural.greaterThan
+    list.add(NativeFunction(naturalDot("greaterThan"), { args: List<SemObject>, _: InterpreterCallback ->
+        val left = args[0] as? SemObject.Natural ?: typeError()
+        val right = args[1] as? SemObject.Natural ?: typeError()
+        SemObject.Boolean(left.value > right.value)
+    }))
+
     // Natural.max
     list.add(NativeFunction(naturalDot("max"), { args: List<SemObject>, _: InterpreterCallback ->
         val list = args[0] as? SemObject.SemList ?: typeError()
@@ -280,6 +287,11 @@ private fun addListFunctions(list: MutableList<NativeFunction>) {
 
 private fun addTryFunctions(list: MutableList<NativeFunction>) {
     val tryDot = fun(name: String) = FunctionId(Package(listOf("Try")), name)
+
+    // Try.failure
+    list.add(NativeFunction(tryDot("failure"), { _: List<SemObject>, _: InterpreterCallback ->
+        SemObject.Try.Failure
+    }))
 
     // Try.assume
     list.add(NativeFunction(tryDot("assume"), { args: List<SemObject>, _: InterpreterCallback ->

--- a/kotlin-interpreter/src/main/kotlin/NativeFunctions.kt
+++ b/kotlin-interpreter/src/main/kotlin/NativeFunctions.kt
@@ -142,6 +142,13 @@ private fun addNaturalFunctions(list: MutableList<NativeFunction>) {
         SemObject.Boolean(left.value == right.value)
     }))
 
+    // Natural.lessThan
+    list.add(NativeFunction(naturalDot("lessThan"), { args: List<SemObject>, _: InterpreterCallback ->
+        val left = args[0] as? SemObject.Natural ?: typeError()
+        val right = args[1] as? SemObject.Natural ?: typeError()
+        SemObject.Boolean(left.value < right.value)
+    }))
+
     // Natural.greaterThan
     list.add(NativeFunction(naturalDot("greaterThan"), { args: List<SemObject>, _: InterpreterCallback ->
         val left = args[0] as? SemObject.Natural ?: typeError()

--- a/kotlin-parser/src/main/kotlin/jsonWriter.kt
+++ b/kotlin-parser/src/main/kotlin/jsonWriter.kt
@@ -48,17 +48,22 @@ private fun addStruct(node: ObjectNode, struct: Struct) {
         addArray(node, "annotations", struct.annotations, ::addAnnotation)
     }
     addArray(node, "members", struct.members, ::addMember)
+    val requires = struct.requires
+    if (requires != null) {
+        addBlock(node.putArray("requires"), requires)
+    }
 }
 
-private fun parseStruct(node: JsonNode): Struct {
+private fun parseStruct(node: JsonNode): UnvalidatedStruct {
     if (!node.isObject()) error("Expected a struct to be an object")
 
     val id = parseFunctionId(node["id"] ?: error("Structs must have an 'id' field"))
     val typeParameters = parseTypeParameters(node["typeParameters"])
     val annotations = parseAnnotations(node["annotations"])
     val members = parseMembers(node["members"])
+    val requires = node["requires"]?.let { parseBlock(it) }
 
-    return Struct(id, typeParameters, members, annotations)
+    return UnvalidatedStruct(id, typeParameters, members, requires, annotations)
 }
 
 private fun parseTypeParameters(node: JsonNode?): List<String> {
@@ -478,7 +483,7 @@ private fun addTypeParameters(node: ArrayNode, typeParameters: List<String>) {
     }
 }
 
-fun fromJson(node: JsonNode): InterpreterContext {
+fun fromJson(node: JsonNode): RawContext {
     if (!node.isObject()) {
         error("Expected an object node")
     }
@@ -490,11 +495,11 @@ fun fromJson(node: JsonNode): InterpreterContext {
         error("Currently no backwards-compatibility support")
     }
 
-    val functions = indexById(parseFunctions(node.get("functions")))
-    val structs = indexById(parseStructs(node.get("structs")))
-    val interfaces = indexById(parseInterfaces(node.get("interfaces")))
+    val functions = parseFunctions(node.get("functions"))
+    val structs = parseStructs(node.get("structs"))
+    val interfaces = parseInterfaces(node.get("interfaces"))
 
-    return InterpreterContext(functions, structs, interfaces)
+    return RawContext(functions, structs, interfaces)
 }
 
 private fun parseFunctions(node: JsonNode): List<Function> {
@@ -502,7 +507,7 @@ private fun parseFunctions(node: JsonNode): List<Function> {
     return node.map { functionNode -> parseFunction(functionNode) }
 }
 
-private fun parseStructs(node: JsonNode): List<Struct> {
+private fun parseStructs(node: JsonNode): List<UnvalidatedStruct> {
     if (!node.isArray()) error("Expected structs to be in an array")
     return node.map { structNode -> parseStruct(structNode) }
 }

--- a/kotlin-parser/src/main/kotlin/parser.kt
+++ b/kotlin-parser/src/main/kotlin/parser.kt
@@ -475,8 +475,6 @@ fun parseFile(file: File): RawContext {
     return parseFileNamed(file.absolutePath)
 }
 
-//private data class RawContents(val functions: List<Function>, val structs: List<UnvalidatedStruct>, val interfaces: List<Interface>)
-
 fun parseFileNamed(filename: String): RawContext {
     val stream = ANTLRFileStream(filename, "UTF-8")
     val rawContents = parseANTLRStreamInner(stream)

--- a/kotlin-parser/src/main/kotlin/validator.kt
+++ b/kotlin-parser/src/main/kotlin/validator.kt
@@ -2,7 +2,6 @@ package semlang.parser
 
 import semlang.api.*
 import semlang.api.Function
-import semlang.api.Type.NamedType.Companion.forParameter
 import semlang.interpreter.getTypeValidatorFor
 import java.util.*
 
@@ -30,34 +29,41 @@ private fun fail(text: String): Nothing {
 
 data class GroundedTypeSignature(val id: FunctionId, val argumentTypes: List<Type>, val outputType: Type)
 
-fun validateContext(context: InterpreterContext, upstreamContexts: List<ValidatedContext>): ValidatedContext {
-    val ownStructs = getStructs(context, upstreamContexts)
-    val ownInterfaces = getInterfaces(context, upstreamContexts)
+fun validateContext(context: RawContext, upstreamContexts: List<ValidatedContext>): ValidatedContext {
+    val typeInfo = collectTypeInfo(context, upstreamContexts)
 
-    val functionTypeSignatures = getFunctionTypeSignatures(context, upstreamContexts)
-    val allFunctionTypeSignatures = getAllFunctionTypeSignatures(functionTypeSignatures, upstreamContexts)
-    val allStructs = getAllStructs(ownStructs, upstreamContexts)
-    val allInterfaces = getAllInterfaces(ownInterfaces, upstreamContexts)
-
-    val ownFunctions = validateFunctions(context.functions, allFunctionTypeSignatures, allStructs, allInterfaces)
+    val ownFunctions = validateFunctions(context.functions, typeInfo)
+    val ownStructs = validateStructs(context.structs, typeInfo)
+    val ownInterfaces = validateInterfaces(context.interfaces, typeInfo)
     return ValidatedContext.create(ownFunctions, ownStructs, ownInterfaces, upstreamContexts)
 }
 
-private fun validateFunctions(functions: Map<FunctionId, Function>, allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>): Map<FunctionId, ValidatedFunction> {
+private fun collectTypeInfo(context: RawContext, upstreamContexts: List<ValidatedContext>): AllTypeInfo {
+    val functionTypeSignatures = getFunctionTypeSignatures(context, upstreamContexts)
+    val allFunctionTypeSignatures = getAllFunctionTypeSignatures(functionTypeSignatures, upstreamContexts)
+    val allStructs = getAllStructsInfo(context.structs, upstreamContexts)
+    val allInterfaces = getAllInterfacesInfo(context.interfaces, upstreamContexts)
+
+    return AllTypeInfo(allFunctionTypeSignatures, allStructs, allInterfaces)
+}
+
+private fun validateFunctions(functions: List<Function>, typeInfo: AllTypeInfo): Map<FunctionId, ValidatedFunction> {
     val validatedFunctions = HashMap<FunctionId, ValidatedFunction>()
-    functions.entries.forEach { entry ->
-        val (id, function) = entry
-        val validatedFunction = validateFunction(function, allFunctionTypeSignatures, structs, interfaces)
-        validatedFunctions.put(id, validatedFunction)
+    functions.forEach { function ->
+        if (validatedFunctions.containsKey(function.id)) {
+            error("Duplicate function ID ${function.id}")
+        }
+        val validatedFunction = validateFunction(function, typeInfo)
+        validatedFunctions.put(function.id, validatedFunction)
     }
     return validatedFunctions
 }
 
-private fun validateFunction(function: Function, allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>): ValidatedFunction {
+private fun validateFunction(function: Function, typeInfo: AllTypeInfo): ValidatedFunction {
     //TODO: Validate that no two arguments have the same name
     //TODO: Validate that type parameters don't share a name with something important
     val variableTypes = getArgumentVariableTypes(function.arguments)
-    val block = validateBlock(function.block, variableTypes, allFunctionTypeSignatures, structs, interfaces, function.id)
+    val block = validateBlock(function.block, variableTypes, typeInfo, function.id)
     if (function.returnType != block.type) {
         fail("Function ${function.id}'s stated return type ${function.returnType} does " +
                 "not match the block's actual return type ${block.type}")
@@ -70,18 +76,24 @@ private fun getArgumentVariableTypes(arguments: List<Argument>): Map<String, Typ
     return arguments.associate { argument -> Pair(argument.name, argument.type) }
 }
 
-private fun validateBlock(block: Block, externalVariableTypes: Map<String, Type>, allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedBlock {
+
+private data class StructTypeInfo(val typeParameters: List<String>, val members: Map<String, Member>, val usesRequires: Boolean)
+private data class InterfaceTypeInfo(val typeParameters: List<String>, val methods: Map<String, Method>)
+
+private data class AllTypeInfo(val allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, val structs: Map<FunctionId, StructTypeInfo>, val interfaces: Map<FunctionId, InterfaceTypeInfo>)
+
+private fun validateBlock(block: Block, externalVariableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedBlock {
     val variableTypes = HashMap(externalVariableTypes)
     val validatedAssignments = ArrayList<ValidatedAssignment>()
     block.assignments.forEach { assignment ->
         if (variableTypes.containsKey(assignment.name)) {
             fail("In function $containingFunctionId, there is a reassignment of the already-assigned variable ${assignment.name}")
         }
-        if (isInvalidVariableName(assignment.name, allFunctionTypeSignatures, structs)) {
+        if (isInvalidVariableName(assignment.name, typeInfo)) {
             fail("In function $containingFunctionId, there is an invalid variable name ${assignment.name}")
         }
 
-        val validatedExpression = validateExpression(assignment.expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
+        val validatedExpression = validateExpression(assignment.expression, variableTypes, typeInfo, containingFunctionId)
         if (assignment.type != null && (validatedExpression.type != assignment.type)) {
             fail("In function $containingFunctionId, the variable ${assignment.name} is supposed to be of type ${assignment.type}, " +
                     "but the expression given has actual type ${validatedExpression.type}")
@@ -90,34 +102,34 @@ private fun validateBlock(block: Block, externalVariableTypes: Map<String, Type>
         validatedAssignments.add(ValidatedAssignment(assignment.name, validatedExpression.type, validatedExpression))
         variableTypes.put(assignment.name, validatedExpression.type)
     }
-    val returnedExpression = validateExpression(block.returnedExpression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
+    val returnedExpression = validateExpression(block.returnedExpression, variableTypes, typeInfo, containingFunctionId)
     return TypedBlock(returnedExpression.type, validatedAssignments, returnedExpression)
 }
 
 //TODO: Construct this more sensibly from more centralized lists
-private val INVALID_VARIABLE_NAMES: Set<String> = setOf("Integer", "Natural", "Boolean", "function", "let", "return", "if", "else", "struct")
+private val INVALID_VARIABLE_NAMES: Set<String> = setOf("Integer", "Natural", "Boolean", "function", "let", "return", "if", "else", "struct", "requires")
 
-private fun isInvalidVariableName(name: String, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>): Boolean {
+private fun isInvalidVariableName(name: String, typeInfo: AllTypeInfo): Boolean {
     val nameAsFunctionId = FunctionId.of(name)
-    return functionTypeSignatures.containsKey(nameAsFunctionId) || structs.containsKey(nameAsFunctionId) || INVALID_VARIABLE_NAMES.contains(name)
+    return typeInfo.allFunctionTypeSignatures.containsKey(nameAsFunctionId) || typeInfo.structs.containsKey(nameAsFunctionId) || INVALID_VARIABLE_NAMES.contains(name)
 }
 
-private fun validateExpression(expression: Expression, variableTypes: Map<String, Type>, allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
+private fun validateExpression(expression: Expression, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
     return when (expression) {
         is Expression.Variable -> validateVariableExpression(expression, variableTypes, containingFunctionId)
-        is Expression.IfThen -> validateIfThenExpression(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
-        is Expression.Follow -> validateFollowExpression(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
-        is Expression.NamedFunctionCall -> validateNamedFunctionCallExpression(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
-        is Expression.ExpressionFunctionCall -> validateExpressionFunctionCallExpression(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
+        is Expression.IfThen -> validateIfThenExpression(expression, variableTypes, typeInfo, containingFunctionId)
+        is Expression.Follow -> validateFollowExpression(expression, variableTypes, typeInfo, containingFunctionId)
+        is Expression.NamedFunctionCall -> validateNamedFunctionCallExpression(expression, variableTypes, typeInfo, containingFunctionId)
+        is Expression.ExpressionFunctionCall -> validateExpressionFunctionCallExpression(expression, variableTypes, typeInfo, containingFunctionId)
 
         is Expression.Literal -> validateLiteralExpression(expression)
-        is Expression.NamedFunctionBinding -> validateNamedFunctionBinding(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
-        is Expression.ExpressionFunctionBinding -> validateExpressionFunctionBinding(expression, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
+        is Expression.NamedFunctionBinding -> validateNamedFunctionBinding(expression, variableTypes, typeInfo, containingFunctionId)
+        is Expression.ExpressionFunctionBinding -> validateExpressionFunctionBinding(expression, variableTypes, typeInfo, containingFunctionId)
     }
 }
 
-private fun validateExpressionFunctionBinding(expression: Expression.ExpressionFunctionBinding, variableTypes: Map<String, Type>, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
-    val functionExpression = validateExpression(expression.functionExpression, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+private fun validateExpressionFunctionBinding(expression: Expression.ExpressionFunctionBinding, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
+    val functionExpression = validateExpression(expression.functionExpression, variableTypes, typeInfo, containingFunctionId)
 
     val functionType = functionExpression.type as? Type.FunctionType ?: fail("The function $containingFunctionId tries to call $functionExpression like a function, but it has a non-function type ${functionExpression.type}")
 
@@ -131,7 +143,7 @@ private fun validateExpressionFunctionBinding(expression: Expression.ExpressionF
         if (binding == null) {
             null
         } else {
-            validateExpression(binding, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+            validateExpression(binding, variableTypes, typeInfo, containingFunctionId)
         }
     }
 
@@ -154,9 +166,9 @@ private fun validateExpressionFunctionBinding(expression: Expression.ExpressionF
     return TypedExpression.ExpressionFunctionBinding(postBindingType, functionExpression, bindings, expression.chosenParameters)
 }
 
-private fun validateNamedFunctionBinding(expression: Expression.NamedFunctionBinding, variableTypes: Map<String, Type>, allFunctionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
+private fun validateNamedFunctionBinding(expression: Expression.NamedFunctionBinding, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
     val functionId = expression.functionId
-    val signature = allFunctionTypeSignatures.get(functionId)
+    val signature = typeInfo.allFunctionTypeSignatures.get(functionId)
     if (signature == null) {
         fail("In function $containingFunctionId, could not find a declaration of a function with ID $functionId")
     }
@@ -177,7 +189,7 @@ private fun validateNamedFunctionBinding(expression: Expression.NamedFunctionBin
         if (binding == null) {
             null
         } else {
-            validateExpression(binding, variableTypes, allFunctionTypeSignatures, structs, interfaces, containingFunctionId)
+            validateExpression(binding, variableTypes, typeInfo, containingFunctionId)
         }
     }
 
@@ -200,54 +212,56 @@ private fun validateNamedFunctionBinding(expression: Expression.NamedFunctionBin
     return TypedExpression.NamedFunctionBinding(postBindingType, functionId, bindings, chosenParameters)
 }
 
-private fun validateFollowExpression(expression: Expression.Follow, variableTypes: Map<String, Type>, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
-    val innerExpression = validateExpression(expression.expression, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+private fun validateFollowExpression(expression: Expression.Follow, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
+    val innerExpression = validateExpression(expression.expression, variableTypes, typeInfo, containingFunctionId)
 
-    val structType = innerExpression.type as? Type.NamedType ?: fail("In function $containingFunctionId, we try to dereference an expression $innerExpression of non-struct type ${innerExpression.type}")
+    val parentNamedType = innerExpression.type as? Type.NamedType ?: fail("In function $containingFunctionId, we try to dereference an expression $innerExpression of non-struct, non-interface type ${innerExpression.type}")
 
-    val struct = structs[structType.id]
-    if (struct != null) {
-        val index = struct.getIndexForName(expression.name)
-        if (index < 0) {
-            fail("In function $containingFunctionId, we try to dereference a non-existent member '${expression.name}' of the struct type $structType")
+    val structInfo = typeInfo.structs[parentNamedType.id]
+    if (structInfo != null) {
+//        val index = structInfo.getIndexForName(expression.name)
+        val member = structInfo.members[expression.name]
+        if (member == null) {
+            fail("In function $containingFunctionId, we try to dereference a non-existent member '${expression.name}' of the struct type $parentNamedType")
         }
         // Type parameters come from the struct definition itself
         // Chosen types come from the struct type known for the variable
-        val typeParameters = struct.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
-        val chosenTypes = structType.getParameterizedTypes()
-        val type = parameterizeType(struct.members[index].type, typeParameters, chosenTypes, struct.id)
+        val typeParameters = structInfo.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
+        val chosenTypes = parentNamedType.getParameterizedTypes()
+        val type = parameterizeType(member.type, typeParameters, chosenTypes, parentNamedType.id)
         //TODO: Ground this if needed
 
         return TypedExpression.Follow(type, innerExpression, expression.name)
     }
 
-    val interfac = interfaces[structType.id]
+    val interfac = typeInfo.interfaces[parentNamedType.id]
     if (interfac != null) {
-        val interfaceType = structType
-        val index = interfac.getIndexForName(expression.name)
-        if (index < 0) {
+        val interfaceType = parentNamedType
+//        val index = interfac.getIndexForName(expression.name)
+        val method = interfac.methods[expression.name]
+        if (method == null) {
             fail("In function $containingFunctionId, we try to reference a non-existent method '${expression.name}' of the interface type $interfaceType")
         }
 
-        val method = interfac.methods[index]
+//        val method = interfac.methods[index]
         val typeParameters = interfac.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
         val chosenTypes = interfaceType.getParameterizedTypes()
-        val type = parameterizeType(method.functionType, typeParameters, chosenTypes, interfac.id)
+        val type = parameterizeType(method.functionType, typeParameters, chosenTypes, parentNamedType.id)
 
         return TypedExpression.Follow(type, innerExpression, expression.name)
     }
 
-    fail("In function $containingFunctionId, we try to dereference an expression $innerExpression of a type $structType that is not recognized as a struct or interface")
+    fail("In function $containingFunctionId, we try to dereference an expression $innerExpression of a type $parentNamedType that is not recognized as a struct or interface")
 }
 
-private fun validateExpressionFunctionCallExpression(expression: Expression.ExpressionFunctionCall, variableTypes: Map<String, Type>, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
-    val functionExpression = validateExpression(expression.functionExpression, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+private fun validateExpressionFunctionCallExpression(expression: Expression.ExpressionFunctionCall, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
+    val functionExpression = validateExpression(expression.functionExpression, variableTypes, typeInfo, containingFunctionId)
 
     val functionType = functionExpression.type as? Type.FunctionType ?: fail("The function $containingFunctionId tries to call $functionExpression like a function, but it has a non-function type ${functionExpression.type}")
 
     val arguments = ArrayList<TypedExpression>()
     expression.arguments.forEach { untypedArgument ->
-        val argument = validateExpression(untypedArgument, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+        val argument = validateExpression(untypedArgument, variableTypes, typeInfo, containingFunctionId)
         arguments.add(argument)
     }
     val argumentTypes = arguments.map(TypedExpression::type)
@@ -259,17 +273,17 @@ private fun validateExpressionFunctionCallExpression(expression: Expression.Expr
     return TypedExpression.ExpressionFunctionCall(functionType.outputType, functionExpression, arguments, expression.chosenParameters)
 }
 
-private fun validateNamedFunctionCallExpression(expression: Expression.NamedFunctionCall, variableTypes: Map<String, Type>, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
+private fun validateNamedFunctionCallExpression(expression: Expression.NamedFunctionCall, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
     val functionId = expression.functionId
 
     val arguments = ArrayList<TypedExpression>()
     expression.arguments.forEach { untypedArgument ->
-        val argument = validateExpression(untypedArgument, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+        val argument = validateExpression(untypedArgument, variableTypes, typeInfo, containingFunctionId)
         arguments.add(argument)
     }
     val argumentTypes = arguments.map(TypedExpression::type)
 
-    val signature = functionTypeSignatures[functionId]
+    val signature = typeInfo.allFunctionTypeSignatures[functionId]
     if (signature == null) {
         fail("The function $containingFunctionId references a function $functionId that was not found")
     }
@@ -324,15 +338,15 @@ private fun validateLiteralExpression(expression: Expression.Literal): TypedExpr
     return TypedExpression.Literal(expression.type, expression.literal)
 }
 
-private fun validateIfThenExpression(expression: Expression.IfThen, variableTypes: Map<String, Type>, functionTypeSignatures: Map<FunctionId, TypeSignature>, structs: Map<FunctionId, Struct>, interfaces: Map<FunctionId, Interface>, containingFunctionId: FunctionId): TypedExpression {
-    val condition = validateExpression(expression.condition, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+private fun validateIfThenExpression(expression: Expression.IfThen, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, containingFunctionId: FunctionId): TypedExpression {
+    val condition = validateExpression(expression.condition, variableTypes, typeInfo, containingFunctionId)
 
     if (condition.type != Type.BOOLEAN) {
         fail("In function $containingFunctionId, an if-then expression has a non-boolean condition expression: $condition")
     }
 
-    val elseBlock = validateBlock(expression.elseBlock, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
-    val thenBlock = validateBlock(expression.thenBlock, variableTypes, functionTypeSignatures, structs, interfaces, containingFunctionId)
+    val elseBlock = validateBlock(expression.elseBlock, variableTypes, typeInfo, containingFunctionId)
+    val thenBlock = validateBlock(expression.thenBlock, variableTypes, typeInfo, containingFunctionId)
 
     val type = try {
         typeUnion(thenBlock.type, elseBlock.type)
@@ -361,55 +375,74 @@ private fun validateVariableExpression(expression: Expression.Variable, variable
     }
 }
 
-private fun getFunctionTypeSignatures(context: InterpreterContext, upstreamContexts: List<ValidatedContext>): Map<FunctionId, TypeSignature> {
+private fun getFunctionTypeSignatures(context: RawContext, upstreamContexts: List<ValidatedContext>): Map<FunctionId, TypeSignature> {
     val signatures = HashMap<FunctionId, TypeSignature>()
 
-    context.structs.entries.forEach { entry ->
-        val (id, struct) = entry
+    context.structs.forEach { struct ->
+        val id = struct.id
         if (signatures.containsKey(id)) {
             fail("Struct name $id has an overlap with a native function")
         }
         signatures.put(id, getStructConstructorSignature(struct))
     }
 
-    context.interfaces.entries.forEach { entry ->
-        val (id, interfac) = entry
+    context.interfaces.forEach { interfac ->
+        val id = interfac.id
         if (signatures.containsKey(id)) {
             fail("Interface name $id has an overlap with a native function or struct")
         }
         signatures.put(interfac.adapterId, toAdapterConstructorSignature(interfac))
         signatures.put(id, toInstanceConstructorSignature(interfac))
     }
-    context.functions.entries.forEach { entry ->
-        val (id, function) = entry
+    context.functions.forEach { function ->
+        val id = function.id
         if (signatures.containsKey(id)) {
-            if (context.structs.keys.contains(id)) {
-                fail("Function name $id overlaps with a struct's or interface's constructor name")
-            } else {
-                fail("Function name $id overlaps with a native function")
-            }
+            fail("Function name $id overlaps with a struct's or interface's constructor name, or with a native function")
         }
         signatures.put(id, getFunctionSignature(function))
     }
     return signatures
 }
 
-private fun addNativeFunctions(signatures: HashMap<FunctionId, TypeSignature>) {
-    signatures.putAll(getNativeFunctionDefinitions())
-}
+//private fun addNativeFunctions(signatures: HashMap<FunctionId, TypeSignature>) {
+//    signatures.putAll(getNativeFunctionDefinitions())
+//}
 
-private fun getStructs(context: InterpreterContext, upstreamContexts: List<ValidatedContext>): Map<FunctionId, Struct> {
-    val structs = HashMap<FunctionId, Struct>()
+private fun validateStructs(structs: List<UnvalidatedStruct>, typeInfo: AllTypeInfo): Map<FunctionId, Struct> {
+    val validatedStructs = HashMap<FunctionId, Struct>()
     // TODO: Validate structs here
-    structs.putAll(context.structs)
-    return structs
+    for (struct in structs) {
+        validatedStructs.put(struct.id, validateStruct(struct, typeInfo))
+    }
+    return validatedStructs
 }
 
-private fun getInterfaces(context: InterpreterContext, upstreamContexts: List<ValidatedContext>): Map<FunctionId, Interface> {
-    val interfaces = HashMap<FunctionId, Interface>()
-    // TODO: Validate interfaces here
-    interfaces.putAll(context.interfaces)
-    return interfaces
+private fun validateStruct(struct: UnvalidatedStruct, typeInfo: AllTypeInfo): Struct {
+    validateMemberNames(struct)
+    val memberTypes = struct.members.associate { member -> member.name to member.type }
+
+    val fakeContainingFunctionId = FunctionId(struct.id.toPackage(), "requires")
+    val requires = struct.requires?.let { validateBlock(it, memberTypes, typeInfo, fakeContainingFunctionId) }
+    if (requires != null && requires.type != Type.BOOLEAN) {
+        error("Struct ${struct.id} has a requires block with inferred type ${requires.type}, but the type should be Boolean")
+    }
+
+    return Struct(struct.id, struct.typeParameters, struct.members, requires, struct.annotations)
+}
+
+private fun validateMemberNames(struct: UnvalidatedStruct) {
+    val allNames = HashSet<String>()
+    for (member in struct.members) {
+        if (allNames.contains(member.name)) {
+            error("Struct ${struct.id} has multiple members named ${member.name}")
+        }
+        allNames.add(member.name)
+    }
+}
+
+private fun validateInterfaces(interfaces: List<Interface>, typeInfo: AllTypeInfo): Map<FunctionId, Interface> {
+    // TODO: Do some actual validation of interfaces
+    return interfaces.associateBy(Interface::id)
 }
 
 private fun getFunctionSignature(function: Function): TypeSignature {
@@ -418,7 +451,7 @@ private fun getFunctionSignature(function: Function): TypeSignature {
     return TypeSignature(function.id, argumentTypes, function.returnType, typeParameters)
 }
 
-private fun getStructConstructorSignature(struct: Struct): TypeSignature {
+private fun getStructConstructorSignature(struct: UnvalidatedStruct): TypeSignature {
     val argumentTypes = struct.members.map(Member::type)
     val typeParameters = struct.typeParameters.map { id -> Type.NamedType.forParameter(id) }
     // TODO: Method for making a type parameter type (String -> Type)
@@ -430,12 +463,37 @@ private fun getAllFunctionTypeSignatures(ownFunctionTypeSignatures: Map<Function
     return getAllEntities(ownFunctionTypeSignatures, ValidatedContext::getAllFunctionSignatures, upstreamContexts)
 }
 
-private fun getAllStructs(ownStructs: Map<FunctionId, Struct>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, Struct> {
-    return getAllEntities(ownStructs, ValidatedContext::getAllStructs, upstreamContexts)
+private fun getAllStructsInfo(ownStructs: List<UnvalidatedStruct>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, StructTypeInfo> {
+//    val allStructs = getAllEntities<UnvalidatedStruct>(ownStructs, ValidatedContext::getAllStructs, upstreamContexts)
+//    allStructs.mapValues { (_, struct) -> StructTypeInfo(struct.typeParameters, struct.members, struct.requiresBlock != null) }
+    val allStructsInfo = HashMap<FunctionId, StructTypeInfo>()
+    upstreamContexts.forEach { context ->
+        context.getAllStructs().forEach { (_, struct) ->
+            allStructsInfo.put(struct.id, StructTypeInfo(struct.typeParameters, struct.members.associateBy(Member::name), struct.requires != null))
+        }
+    }
+    ownStructs.forEach { struct ->
+        // TODO: We need something much more robust to prevent name collisions
+        if (allStructsInfo.containsKey(struct.id)) {
+            error("A struct with key ${struct.id} already exists!")
+        }
+        allStructsInfo.put(struct.id, StructTypeInfo(struct.typeParameters, struct.members.associateBy(Member::name), struct.requires != null))
+    }
+    return allStructsInfo
 }
 
-private fun getAllInterfaces(ownInterfaces: Map<FunctionId, Interface>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, Interface> {
-    return getAllEntities(ownInterfaces, ValidatedContext::getAllInterfaces, upstreamContexts)
+private fun getAllInterfacesInfo(ownInterfaces: List<Interface>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, InterfaceTypeInfo> {
+//    val allInterfaces = getAllEntities(ownInterfaces, ValidatedContext::getAllInterfaces, upstreamContexts)
+    val allInterfaces = HashMap<FunctionId, Interface>()
+
+    upstreamContexts.forEach { context ->
+        allInterfaces.putAll(context.getAllInterfaces())
+    }
+    allInterfaces.putAll(ownInterfaces.associateBy(Interface::id))
+
+    return allInterfaces.mapValues { (_, interfac) ->
+        InterfaceTypeInfo(interfac.typeParameters, interfac.methods.associateBy(Method::name))
+    }
 }
 
 private fun <T> getAllEntities(own: Map<FunctionId, T>, theirs: (ValidatedContext) -> Map<FunctionId, T>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, T> {

--- a/kotlin-parser/src/main/kotlin/validator.kt
+++ b/kotlin-parser/src/main/kotlin/validator.kt
@@ -219,11 +219,11 @@ private fun validateFollowExpression(expression: Expression.Follow, variableType
 
     val structInfo = typeInfo.structs[parentNamedType.id]
     if (structInfo != null) {
-//        val index = structInfo.getIndexForName(expression.name)
         val member = structInfo.members[expression.name]
         if (member == null) {
             fail("In function $containingFunctionId, we try to dereference a non-existent member '${expression.name}' of the struct type $parentNamedType")
         }
+
         // Type parameters come from the struct definition itself
         // Chosen types come from the struct type known for the variable
         val typeParameters = structInfo.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
@@ -237,13 +237,11 @@ private fun validateFollowExpression(expression: Expression.Follow, variableType
     val interfac = typeInfo.interfaces[parentNamedType.id]
     if (interfac != null) {
         val interfaceType = parentNamedType
-//        val index = interfac.getIndexForName(expression.name)
         val method = interfac.methods[expression.name]
         if (method == null) {
             fail("In function $containingFunctionId, we try to reference a non-existent method '${expression.name}' of the interface type $interfaceType")
         }
 
-//        val method = interfac.methods[index]
         val typeParameters = interfac.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
         val chosenTypes = interfaceType.getParameterizedTypes()
         val type = parameterizeType(method.functionType, typeParameters, chosenTypes, parentNamedType.id)
@@ -406,7 +404,6 @@ private fun getFunctionTypeSignatures(context: RawContext, upstreamContexts: Lis
 
 private fun validateStructs(structs: List<UnvalidatedStruct>, typeInfo: AllTypeInfo): Map<FunctionId, Struct> {
     val validatedStructs = HashMap<FunctionId, Struct>()
-    // TODO: Validate structs here
     for (struct in structs) {
         validatedStructs.put(struct.id, validateStruct(struct, typeInfo))
     }

--- a/kotlin-parser/src/main/kotlin/validator.kt
+++ b/kotlin-parser/src/main/kotlin/validator.kt
@@ -383,7 +383,7 @@ private fun getFunctionTypeSignatures(context: RawContext, upstreamContexts: Lis
         if (signatures.containsKey(id)) {
             fail("Struct name $id has an overlap with a native function")
         }
-        signatures.put(id, getStructConstructorSignature(struct))
+        signatures.put(id, struct.getConstructorSignature())
     }
 
     context.interfaces.forEach { interfac ->
@@ -403,10 +403,6 @@ private fun getFunctionTypeSignatures(context: RawContext, upstreamContexts: Lis
     }
     return signatures
 }
-
-//private fun addNativeFunctions(signatures: HashMap<FunctionId, TypeSignature>) {
-//    signatures.putAll(getNativeFunctionDefinitions())
-//}
 
 private fun validateStructs(structs: List<UnvalidatedStruct>, typeInfo: AllTypeInfo): Map<FunctionId, Struct> {
     val validatedStructs = HashMap<FunctionId, Struct>()
@@ -451,21 +447,11 @@ private fun getFunctionSignature(function: Function): TypeSignature {
     return TypeSignature(function.id, argumentTypes, function.returnType, typeParameters)
 }
 
-private fun getStructConstructorSignature(struct: UnvalidatedStruct): TypeSignature {
-    val argumentTypes = struct.members.map(Member::type)
-    val typeParameters = struct.typeParameters.map { id -> Type.NamedType.forParameter(id) }
-    // TODO: Method for making a type parameter type (String -> Type)
-    val outputType = Type.NamedType(struct.id, typeParameters)
-    return TypeSignature(struct.id, argumentTypes, outputType, typeParameters)
-}
-
 private fun getAllFunctionTypeSignatures(ownFunctionTypeSignatures: Map<FunctionId, TypeSignature>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, TypeSignature> {
     return getAllEntities(ownFunctionTypeSignatures, ValidatedContext::getAllFunctionSignatures, upstreamContexts)
 }
 
 private fun getAllStructsInfo(ownStructs: List<UnvalidatedStruct>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, StructTypeInfo> {
-//    val allStructs = getAllEntities<UnvalidatedStruct>(ownStructs, ValidatedContext::getAllStructs, upstreamContexts)
-//    allStructs.mapValues { (_, struct) -> StructTypeInfo(struct.typeParameters, struct.members, struct.requiresBlock != null) }
     val allStructsInfo = HashMap<FunctionId, StructTypeInfo>()
     upstreamContexts.forEach { context ->
         context.getAllStructs().forEach { (_, struct) ->
@@ -483,7 +469,6 @@ private fun getAllStructsInfo(ownStructs: List<UnvalidatedStruct>, upstreamConte
 }
 
 private fun getAllInterfacesInfo(ownInterfaces: List<Interface>, upstreamContexts: List<ValidatedContext>): Map<FunctionId, InterfaceTypeInfo> {
-//    val allInterfaces = getAllEntities(ownInterfaces, ValidatedContext::getAllInterfaces, upstreamContexts)
     val allInterfaces = HashMap<FunctionId, Interface>()
 
     upstreamContexts.forEach { context ->

--- a/kotlin-parser/src/main/kotlin/writer.kt
+++ b/kotlin-parser/src/main/kotlin/writer.kt
@@ -37,6 +37,14 @@ private fun writeStruct(struct: Struct, writer: Writer) {
               .append(": ")
               .appendln(member.type.toString())
     }
+    val requires = struct.requires
+    if (requires != null) {
+        writer.append(SINGLE_INDENTATION)
+              .appendln("requires {")
+        writeBlock(requires, 2, writer)
+        writer.append(SINGLE_INDENTATION)
+              .appendln("}")
+    }
     writer.appendln("}")
           .appendln()
 }

--- a/kotlin-parser/src/test/semlang/validatorTests/fail/structs1.sem
+++ b/kotlin-parser/src/test/semlang/validatorTests/fail/structs1.sem
@@ -1,0 +1,9 @@
+// Double definition of same struct name, same contents
+
+struct Foo {
+  a: Integer
+}
+
+struct Foo {
+  a: Integer
+}

--- a/kotlin-parser/src/test/semlang/validatorTests/fail/structs2.sem
+++ b/kotlin-parser/src/test/semlang/validatorTests/fail/structs2.sem
@@ -1,0 +1,9 @@
+// Double definition of same struct name, different contents
+
+struct Foo {
+  a: Integer
+}
+
+struct Foo {
+  b: Boolean
+}

--- a/kotlin-parser/src/test/semlang/validatorTests/fail/structs3.sem
+++ b/kotlin-parser/src/test/semlang/validatorTests/fail/structs3.sem
@@ -1,0 +1,6 @@
+// Double definition of same member name, same type
+
+struct Foo {
+  a: Integer
+  a: Integer
+}

--- a/kotlin-parser/src/test/semlang/validatorTests/fail/structs4.sem
+++ b/kotlin-parser/src/test/semlang/validatorTests/fail/structs4.sem
@@ -1,0 +1,6 @@
+// Double definition of same member name, different type
+
+struct Foo {
+  a: Integer
+  a: Boolean
+}

--- a/kotlin-write-java/src/main/kotlin/writeJava.kt
+++ b/kotlin-write-java/src/main/kotlin/writeJava.kt
@@ -789,6 +789,7 @@ private class JavaCodeWriter(val context: ValidatedContext, val javaPackage: Lis
 
         val tries = Package(listOf("Try"))
         val javaTries = ClassName.bestGuess("net.semlang.java.Tries")
+        map.put(FunctionId(tries, "failure"), StaticFunctionCallStrategy(javaTries, "failure"))
         map.put(FunctionId(tries, "assume"), StaticFunctionCallStrategy(javaTries, "assume"))
         map.put(FunctionId(tries, "map"), StaticFunctionCallStrategy(javaTries, "map"))
 

--- a/semlang-corpus/src/main/semlang/codePoints1.sem
+++ b/semlang-corpus/src/main/semlang/codePoints1.sem
@@ -1,0 +1,12 @@
+@Test("['0']: 'success(0)'")
+@Test("['70']: 'success(70)'")
+@Test("['1114111']: 'success(1114111)'")
+@Test("['1114112']: 'failure'")
+function createCodePoint(value: Natural): Try<Natural> {
+  let codePointMaybe = Unicode.CodePoint(value)
+  Try.map<Unicode.CodePoint, Natural>(codePointMaybe, getCodePointValue|(_))
+}
+
+function getCodePointValue(codePoint: Unicode.CodePoint): Natural {
+  codePoint->value
+}

--- a/semlang-corpus/src/main/semlang/requires1.sem
+++ b/semlang-corpus/src/main/semlang/requires1.sem
@@ -5,71 +5,14 @@ struct WholeNumber {
   }
 }
 
-//@Test("['1']: 'success(1)'")
-//@Test("['123']: 'success(123)'")
+@Test("['1']: 'success(1)'")
+@Test("['123']: 'success(123)'")
 @Test("['0']: 'failure'")
 function testWholeNumber(input: Natural): Try<Natural> {
-//  let wholeNumber: Try<WholeNumber> = WholeNumber(input)
-//  Try.map<WholeNumber, Natural>(wholeNumber, getWholeNumberValue|(_))
-  Try.failure<Natural>()
+  let wholeNumber: Try<WholeNumber> = WholeNumber(input)
+  Try.map<WholeNumber, Natural>(wholeNumber, getWholeNumberValue|(_))
 }
 
 function getWholeNumberValue(wholeNumber: WholeNumber): Natural {
   wholeNumber->value
 }
-
-/*
-Okay, more second-guessing. Do I really want this vs. a validation-based approach?
-And should I consider some other syntax to avoid breaking invariants like "the obvious
-signature of a function is the one you use when calling it"?
-
-More specific thoughts:
-- I want to keep separate types separate and not easily allow e.g. a CodePoint to be
-  passed in where an Integer is expected. This might be a mistake, but it can be
-  handled in dialects and handling it in the opposite direction would be harder.
-  - This makes modelling things as structs more intuitive, arguably.
-- As mentioned before, we probably want to be able to have these restricted types with
-  multi-member structs anyway.
-- I guess we can have a validation function? Arguably when we get error types handled
-  in Try<>, we should make the type of error produced configurable, which could get
-  tricky. (Though that can be wrapped anyway.)
-
-How would something like this look by comparison?:
-
-define type CodePoint as { value: Natural } via function CodePoint(val: Natural): Try<CodePoint> {
-  if (Natural.lessThan(val, Natural."1234567890")) {
-    Try.success(CodePoint(val))
-  } else {
-    Try.failure()
-  }
-}
-
-So I think the argument against these Try-constructors in general is that if we ever have
-some simple serialization scheme, there's no real way to validate that things of these
-types were a valid outcome of these functions. And part of our safety is that we don't want
-things like Natural (if that gets converted) to be a negative number that we pass to
-List.get.
-
-And if the concept of being a "lingua franca of functions" has any appeal, it wouldn't make
-sense to not also be able to pass around arguments for those functions.
-
-By contrast, a validation approach would make it easier to ___.
-
-For example:
-
-struct myCode.OneIndexedNatural {
-  value: Natural
-  requires {
-    Natural.lessThan(value, Natural."1234567890")
-  }
-}
-
-In this case, whatever is after "requires" is parsed as a block, which is required to be of
-Boolean type. The presence of a requires block implies that the automatically generated
-constructor for the struct will return Try<T> instead of T.
-
-We might someday want multiple such blocks, but for now this works.
-
-Possible names: require[s], precondition[s], validate, validation, test, condition(s), check,
-verify, assert...
-*/

--- a/semlang-corpus/src/main/semlang/requires1.sem
+++ b/semlang-corpus/src/main/semlang/requires1.sem
@@ -1,0 +1,75 @@
+struct WholeNumber {
+  value: Natural
+  requires {
+    Natural.greaterThan(value, Natural."0")
+  }
+}
+
+//@Test("['1']: 'success(1)'")
+//@Test("['123']: 'success(123)'")
+@Test("['0']: 'failure'")
+function testWholeNumber(input: Natural): Try<Natural> {
+//  let wholeNumber: Try<WholeNumber> = WholeNumber(input)
+//  Try.map<WholeNumber, Natural>(wholeNumber, getWholeNumberValue|(_))
+  Try.failure<Natural>()
+}
+
+function getWholeNumberValue(wholeNumber: WholeNumber): Natural {
+  wholeNumber->value
+}
+
+/*
+Okay, more second-guessing. Do I really want this vs. a validation-based approach?
+And should I consider some other syntax to avoid breaking invariants like "the obvious
+signature of a function is the one you use when calling it"?
+
+More specific thoughts:
+- I want to keep separate types separate and not easily allow e.g. a CodePoint to be
+  passed in where an Integer is expected. This might be a mistake, but it can be
+  handled in dialects and handling it in the opposite direction would be harder.
+  - This makes modelling things as structs more intuitive, arguably.
+- As mentioned before, we probably want to be able to have these restricted types with
+  multi-member structs anyway.
+- I guess we can have a validation function? Arguably when we get error types handled
+  in Try<>, we should make the type of error produced configurable, which could get
+  tricky. (Though that can be wrapped anyway.)
+
+How would something like this look by comparison?:
+
+define type CodePoint as { value: Natural } via function CodePoint(val: Natural): Try<CodePoint> {
+  if (Natural.lessThan(val, Natural."1234567890")) {
+    Try.success(CodePoint(val))
+  } else {
+    Try.failure()
+  }
+}
+
+So I think the argument against these Try-constructors in general is that if we ever have
+some simple serialization scheme, there's no real way to validate that things of these
+types were a valid outcome of these functions. And part of our safety is that we don't want
+things like Natural (if that gets converted) to be a negative number that we pass to
+List.get.
+
+And if the concept of being a "lingua franca of functions" has any appeal, it wouldn't make
+sense to not also be able to pass around arguments for those functions.
+
+By contrast, a validation approach would make it easier to ___.
+
+For example:
+
+struct myCode.OneIndexedNatural {
+  value: Natural
+  requires {
+    Natural.lessThan(value, Natural."1234567890")
+  }
+}
+
+In this case, whatever is after "requires" is parsed as a block, which is required to be of
+Boolean type. The presence of a requires block implies that the automatically generated
+constructor for the struct will return Try<T> instead of T.
+
+We might someday want multiple such blocks, but for now this works.
+
+Possible names: require[s], precondition[s], validate, validation, test, condition(s), check,
+verify, assert...
+*/

--- a/semlang-corpus/src/main/semlang/try1.sem
+++ b/semlang-corpus/src/main/semlang/try1.sem
@@ -1,0 +1,4 @@
+@Test("[]: 'failure'")
+function testFailure(): Try<Integer> {
+    Try.failure<Integer>()
+}


### PR DESCRIPTION
This allows structs to do a better job defining data types, as they can now ensure certain properties of their values. For example, CodePoints will be guaranteed to be a valid code point.