### PR TITLE
Use resolved references in validated code objects

### DIFF
--- a/kotlin/semlang-api/src/main/kotlin/net/semlang/api/language.kt
+++ b/kotlin/semlang-api/src/main/kotlin/net/semlang/api/language.kt
@@ -1,6 +1,6 @@
 package net.semlang.api
 
-import java.util.ArrayList
+import java.util.*
 
 
 // An EntityId uniquely identifies an entity within a module. An EntityRef refers to an entity that may be in this
@@ -52,177 +52,55 @@ data class ResolvedEntityRef(val module: ModuleId, val id: EntityId) {
     }
 }
 
-// TODO: Are these actually useful?
-//interface ParameterizableType {
-//    fun getParameterizedTypes(): List<Type>
-//}
-
-//private fun replaceParametersUnvalidated(parameters: List<UnvalidatedType>, parameterMap: Map<UnvalidatedType, UnvalidatedType>): List<UnvalidatedType> {
-//    return parameters.map { type ->
-//        parameterMap.getOrElse(type, fun (): UnvalidatedType {return type})
-//    }
-//}
-
-private fun replaceParameters(parameters: List<Type>, parameterMap: Map<Type, Type>): List<Type> {
+private fun replaceParametersUnvalidated(parameters: List<UnvalidatedType>, parameterMap: Map<UnvalidatedType, UnvalidatedType>): List<UnvalidatedType> {
     return parameters.map { type ->
-        parameterMap.getOrElse(type, fun (): Type {return type})
+        parameterMap.getOrElse(type, fun (): UnvalidatedType {return type})
     }
 }
 
-//sealed class UnvalidatedType {
-//    abstract fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType
-//    abstract protected fun getTypeString(): String
-//    override fun toString(): String {
-//        return getTypeString()
-//    }
-//
-//    object INTEGER : UnvalidatedType() {
-//        override fun getTypeString(): String {
-//            return "Integer"
-//        }
-//
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return this
-//        }
-//    }
-//    object NATURAL : UnvalidatedType() {
-//        override fun getTypeString(): String {
-//            return "Natural"
-//        }
-//
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return this
-//        }
-//    }
-//    object BOOLEAN : UnvalidatedType() {
-//        override fun getTypeString(): String {
-//            return "Boolean"
-//        }
-//
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return this
-//        }
-//    }
-//
-//    data class List(val parameter: UnvalidatedType): UnvalidatedType() {
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return List(parameter.replacingParameters(parameterMap))
-//        }
-//
-//        override fun getTypeString(): String {
-//            return "List<$parameter>"
-//        }
-//
-//        override fun toString(): String {
-//            return getTypeString()
-//        }
-//    }
-//
-//    data class Try(val parameter: UnvalidatedType): UnvalidatedType() {
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return Try(parameter.replacingParameters(parameterMap))
-//        }
-//
-//        override fun getTypeString(): String {
-//            return "Try<$parameter>"
-//        }
-//
-//        override fun toString(): String {
-//            return getTypeString()
-//        }
-//    }
-//
-//    data class FunctionType(val argTypes: kotlin.collections.List<UnvalidatedType>, val outputType: UnvalidatedType): UnvalidatedType() {
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            return FunctionType(argTypes.map { type -> type.replacingParameters(parameterMap) },
-//                    outputType.replacingParameters(parameterMap))
-//        }
-//
-//        override fun getTypeString(): String {
-//            return "(" +
-//                    argTypes.joinToString(", ") +
-//                    ") -> " +
-//                    outputType.toString()
-//        }
-//
-//        override fun toString(): String {
-//            return getTypeString()
-//        }
-//    }
-//
-//    //TODO: In the validator, validate that it does not share a name with a default type
-//    data class NamedType(val ref: EntityRef, val parameters: kotlin.collections.List<UnvalidatedType> = listOf()): UnvalidatedType() {
-//        companion object {
-//            fun forParameter(name: String): NamedType {
-//                return NamedType(EntityRef(null, EntityId(listOf(name))), listOf())
-//            }
-//        }
-//        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
-//            val replacement = parameterMap[this]
-//            if (replacement != null) {
-//                // TODO: Should this have replaceParameters applied to it?
-//                return replacement
-//            }
-//            return NamedType(ref,
-//                    replaceParametersUnvalidated(parameters, parameterMap))
-//        }
-//
-//        fun getParameterizedTypes(): kotlin.collections.List<UnvalidatedType> {
-//            return parameters
-//        }
-//
-//        override fun getTypeString(): String {
-//            return ref.toString() +
-//                if (parameters.isEmpty()) {
-//                    ""
-//                } else {
-//                    "<" + parameters.joinToString(", ") + ">"
-//                }
-//        }
-//
-//        override fun toString(): String {
-//            return super.toString()
-//        }
+//private fun replaceParameters(parameters: List<Type>, parameterMap: Map<out Type, Type>): List<Type> {
+//    return parameters.map { type ->
+//        parameterMap.getOrElse(type, fun (): Type {return type})
 //    }
 //}
 
-sealed class Type {
-    abstract fun replacingParameters(parameterMap: Map<Type, Type>): Type
+sealed class UnvalidatedType {
+    abstract fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType
     abstract protected fun getTypeString(): String
     override fun toString(): String {
         return getTypeString()
     }
 
-    object INTEGER : Type() {
+    object INTEGER : UnvalidatedType() {
         override fun getTypeString(): String {
             return "Integer"
         }
 
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return this
         }
     }
-    object NATURAL : Type() {
+    object NATURAL : UnvalidatedType() {
         override fun getTypeString(): String {
             return "Natural"
         }
 
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return this
         }
     }
-    object BOOLEAN : Type() {
+    object BOOLEAN : UnvalidatedType() {
         override fun getTypeString(): String {
             return "Boolean"
         }
 
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return this
         }
     }
 
-    data class List(val parameter: Type): Type() {
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+    data class List(val parameter: UnvalidatedType): UnvalidatedType() {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return List(parameter.replacingParameters(parameterMap))
         }
 
@@ -235,8 +113,8 @@ sealed class Type {
         }
     }
 
-    data class Try(val parameter: Type): Type() {
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+    data class Try(val parameter: UnvalidatedType): UnvalidatedType() {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return Try(parameter.replacingParameters(parameterMap))
         }
 
@@ -249,8 +127,8 @@ sealed class Type {
         }
     }
 
-    data class FunctionType(val argTypes: kotlin.collections.List<Type>, val outputType: Type): Type() {
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+    data class FunctionType(val argTypes: kotlin.collections.List<UnvalidatedType>, val outputType: UnvalidatedType): UnvalidatedType() {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             return FunctionType(argTypes.map { type -> type.replacingParameters(parameterMap) },
                     outputType.replacingParameters(parameterMap))
         }
@@ -267,21 +145,161 @@ sealed class Type {
         }
     }
 
-    //TODO: In the validator, validate that it does not share a name with a default type
-    data class NamedType(val ref: EntityRef, val parameters: kotlin.collections.List<Type> = listOf()): Type() {
+    data class NamedType(val ref: EntityRef, val parameters: kotlin.collections.List<UnvalidatedType> = listOf()): UnvalidatedType() {
         companion object {
             fun forParameter(name: String): NamedType {
                 return NamedType(EntityRef(null, EntityId(listOf(name))), listOf())
             }
         }
-        override fun replacingParameters(parameterMap: Map<Type, Type>): Type {
+        override fun replacingParameters(parameterMap: Map<UnvalidatedType, UnvalidatedType>): UnvalidatedType {
             val replacement = parameterMap[this]
             if (replacement != null) {
                 // TODO: Should this have replaceParameters applied to it?
                 return replacement
             }
             return NamedType(ref,
-                    replaceParameters(parameters, parameterMap))
+                    replaceParametersUnvalidated(parameters, parameterMap))
+        }
+
+        fun getParameterizedTypes(): kotlin.collections.List<UnvalidatedType> {
+            return parameters
+        }
+
+        override fun getTypeString(): String {
+            return ref.toString() +
+                if (parameters.isEmpty()) {
+                    ""
+                } else {
+                    "<" + parameters.joinToString(", ") + ">"
+                }
+        }
+
+        override fun toString(): String {
+            return super.toString()
+        }
+    }
+}
+
+/**
+ * Note: The hashCode() and equals() methods for [Type.NamedType] ignore [originalRef], which is provided for a narrow
+ * range of reasons -- primarily, converting back to the original unvalidated code. This may cause odd behavior if
+ * you put Types in a set or as the key of a map, but it makes equality checking correct for the purposes of checking
+ * that types agree with one another.
+ */
+sealed class Type {
+    abstract fun replacingParameters(parameterMap: Map<out Type, Type>): Type
+    abstract protected fun getTypeString(): String
+    override fun toString(): String {
+        return getTypeString()
+    }
+
+    object INTEGER : Type() {
+        override fun getTypeString(): String {
+            return "Integer"
+        }
+
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return this
+        }
+    }
+    object NATURAL : Type() {
+        override fun getTypeString(): String {
+            return "Natural"
+        }
+
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return this
+        }
+    }
+    object BOOLEAN : Type() {
+        override fun getTypeString(): String {
+            return "Boolean"
+        }
+
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return this
+        }
+    }
+
+    data class List(val parameter: Type): Type() {
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return List(parameter.replacingParameters(parameterMap))
+        }
+
+        override fun getTypeString(): String {
+            return "List<$parameter>"
+        }
+
+        override fun toString(): String {
+            return getTypeString()
+        }
+    }
+
+    data class Try(val parameter: Type): Type() {
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return Try(parameter.replacingParameters(parameterMap))
+        }
+
+        override fun getTypeString(): String {
+            return "Try<$parameter>"
+        }
+
+        override fun toString(): String {
+            return getTypeString()
+        }
+    }
+
+    data class FunctionType(val argTypes: kotlin.collections.List<Type>, val outputType: Type): Type() {
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            return FunctionType(argTypes.map { type -> type.replacingParameters(parameterMap) },
+                    outputType.replacingParameters(parameterMap))
+        }
+
+        override fun getTypeString(): String {
+            return "(" +
+                    argTypes.joinToString(", ") +
+                    ") -> " +
+                    outputType.toString()
+        }
+
+        override fun toString(): String {
+            return getTypeString()
+        }
+    }
+
+    data class ParameterType(val name: String): Type() {
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            val replacement = parameterMap[this]
+            return if (replacement != null) replacement else this
+        }
+
+        override fun getTypeString(): String {
+            return name
+        }
+
+        override fun toString(): String {
+            return name
+        }
+    }
+
+    /**
+     * Note: The hashCode() and equals() methods for this class ignore [originalRef], which is provided for a narrow
+     * range of reasons -- primarily, converting back to the original unvalidated code. This may cause odd behavior if
+     * you put Types in a set or as the key of a map, but it makes equality checking correct for the purposes of checking
+     * that types agree with one another.
+     */
+    // TODO: Should "ref" be an EntityResolution? Either way, stop passing originalRef to resolvers
+    data class NamedType(val ref: ResolvedEntityRef, val originalRef: EntityRef, val parameters: kotlin.collections.List<Type> = listOf()): Type() {
+        override fun replacingParameters(parameterMap: Map<out Type, Type>): Type {
+            val replacement = parameterMap[this]
+            if (replacement != null) {
+                // TODO: Should this have replaceParameters applied to it?
+                return replacement
+            }
+            return NamedType(ref,
+                    originalRef,
+                    parameters.map { parameter -> parameter.replacingParameters(parameterMap) }
+            )
         }
 
         fun getParameterizedTypes(): kotlin.collections.List<Type> {
@@ -298,13 +316,39 @@ sealed class Type {
         }
 
         override fun toString(): String {
-            return super.toString()
+            return getTypeString()
+        }
+
+        /**
+         * Ignores the value of __.
+         */
+        override fun equals(other: Any?): Boolean {
+            if (this === other) {
+                return true
+            }
+            if (other == null) {
+                return false
+            }
+            if (other !is NamedType) {
+                return false
+            }
+            return Objects.equals(ref, other.ref) && Objects.equals(parameters, other.parameters)
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(ref, parameters)
         }
     }
 }
 
 // TODO: Maybe rename FunctionSignature?
-data class TypeSignature(override val id: EntityId, val argumentTypes: List<Type>, val outputType: Type, val typeParameters: List<Type> = listOf()): HasId
+data class UnvalidatedTypeSignature(override val id: EntityId, val argumentTypes: List<UnvalidatedType>, val outputType: UnvalidatedType, val typeParameters: List<String> = listOf()): HasId {
+    fun getFunctionType(): UnvalidatedType.FunctionType {
+        return UnvalidatedType.FunctionType(argumentTypes, outputType)
+    }
+}
+
+data class TypeSignature(override val id: EntityId, val argumentTypes: List<Type>, val outputType: Type, val typeParameters: List<String> = listOf()): HasId
 
 data class Position(val lineNumber: Int, val column: Int, val rawIndex: Int)
 data class Range(val start: Position, val end: Position)
@@ -320,13 +364,13 @@ sealed class AnnotationArgument {
 sealed class AmbiguousExpression {
     abstract val location: Location
     data class Variable(val name: String, override val location: Location): AmbiguousExpression()
-    data class VarOrNamedFunctionBinding(val functionIdOrVariable: EntityRef, val bindings: List<AmbiguousExpression?>, val chosenParameters: List<Type>, override val location: Location): AmbiguousExpression()
-    data class ExpressionOrNamedFunctionBinding(val expression: AmbiguousExpression, val bindings: List<AmbiguousExpression?>, val chosenParameters: List<Type>, override val location: Location): AmbiguousExpression()
+    data class VarOrNamedFunctionBinding(val functionIdOrVariable: EntityRef, val bindings: List<AmbiguousExpression?>, val chosenParameters: List<UnvalidatedType>, override val location: Location): AmbiguousExpression()
+    data class ExpressionOrNamedFunctionBinding(val expression: AmbiguousExpression, val bindings: List<AmbiguousExpression?>, val chosenParameters: List<UnvalidatedType>, override val location: Location): AmbiguousExpression()
     data class IfThen(val condition: AmbiguousExpression, val thenBlock: AmbiguousBlock, val elseBlock: AmbiguousBlock, override val location: Location): AmbiguousExpression()
-    data class VarOrNamedFunctionCall(val functionIdOrVariable: EntityRef, val arguments: List<AmbiguousExpression>, val chosenParameters: List<Type>, override val location: Location, val varOrNameLocation: Location?): AmbiguousExpression()
-    data class ExpressionOrNamedFunctionCall(val expression: AmbiguousExpression, val arguments: List<AmbiguousExpression>, val chosenParameters: List<Type>, override val location: Location, val expressionOrNameLocation: Location): AmbiguousExpression()
-    data class Literal(val type: Type, val literal: String, override val location: Location): AmbiguousExpression()
-    data class ListLiteral(val contents: List<AmbiguousExpression>, val chosenParameter: Type, override val location: Location): AmbiguousExpression()
+    data class VarOrNamedFunctionCall(val functionIdOrVariable: EntityRef, val arguments: List<AmbiguousExpression>, val chosenParameters: List<UnvalidatedType>, override val location: Location, val varOrNameLocation: Location?): AmbiguousExpression()
+    data class ExpressionOrNamedFunctionCall(val expression: AmbiguousExpression, val arguments: List<AmbiguousExpression>, val chosenParameters: List<UnvalidatedType>, override val location: Location, val expressionOrNameLocation: Location): AmbiguousExpression()
+    data class Literal(val type: UnvalidatedType, val literal: String, override val location: Location): AmbiguousExpression()
+    data class ListLiteral(val contents: List<AmbiguousExpression>, val chosenParameter: UnvalidatedType, override val location: Location): AmbiguousExpression()
     data class Follow(val structureExpression: AmbiguousExpression, val name: String, override val location: Location): AmbiguousExpression()
     data class InlineFunction(val arguments: List<UnvalidatedArgument>, val block: AmbiguousBlock, override val location: Location): AmbiguousExpression()
 }
@@ -336,13 +380,13 @@ sealed class Expression {
     abstract val location: Location?
     data class Variable(val name: String, override val location: Location?): Expression()
     data class IfThen(val condition: Expression, val thenBlock: Block, val elseBlock: Block, override val location: Location?): Expression()
-    data class NamedFunctionCall(val functionRef: EntityRef, val arguments: List<Expression>, val chosenParameters: List<Type>, override val location: Location?, val functionRefLocation: Location?): Expression()
+    data class NamedFunctionCall(val functionRef: EntityRef, val arguments: List<Expression>, val chosenParameters: List<UnvalidatedType>, override val location: Location?, val functionRefLocation: Location?): Expression()
     //TODO: Make position of chosenParamters consistent with bindings below
-    data class ExpressionFunctionCall(val functionExpression: Expression, val arguments: List<Expression>, val chosenParameters: List<Type>, override val location: Location?): Expression()
-    data class Literal(val type: Type, val literal: String, override val location: Location?): Expression()
-    data class ListLiteral(val contents: List<Expression>, val chosenParameter: Type, override val location: Location?): Expression()
-    data class NamedFunctionBinding(val functionRef: EntityRef, val bindings: List<Expression?>, val chosenParameters: List<Type>, override val location: Location?): Expression()
-    data class ExpressionFunctionBinding(val functionExpression: Expression, val bindings: List<Expression?>, val chosenParameters: List<Type>, override val location: Location?): Expression()
+    data class ExpressionFunctionCall(val functionExpression: Expression, val arguments: List<Expression>, val chosenParameters: List<UnvalidatedType>, override val location: Location?): Expression()
+    data class Literal(val type: UnvalidatedType, val literal: String, override val location: Location?): Expression()
+    data class ListLiteral(val contents: List<Expression>, val chosenParameter: UnvalidatedType, override val location: Location?): Expression()
+    data class NamedFunctionBinding(val functionRef: EntityRef, val bindings: List<Expression?>, val chosenParameters: List<UnvalidatedType>, override val location: Location?): Expression()
+    data class ExpressionFunctionBinding(val functionExpression: Expression, val bindings: List<Expression?>, val chosenParameters: List<UnvalidatedType>, override val location: Location?): Expression()
     data class Follow(val structureExpression: Expression, val name: String, override val location: Location?): Expression()
     data class InlineFunction(val arguments: List<UnvalidatedArgument>, val block: Block, override val location: Location?): Expression()
 }
@@ -361,20 +405,20 @@ sealed class TypedExpression {
     data class InlineFunction(override val type: Type, val arguments: List<Argument>, val boundVars: List<Argument>, val block: TypedBlock): TypedExpression()
 }
 
-data class AmbiguousAssignment(val name: String, val type: Type?, val expression: AmbiguousExpression, val nameLocation: Location?)
-data class Assignment(val name: String, val type: Type?, val expression: Expression, val nameLocation: Location?)
+data class AmbiguousAssignment(val name: String, val type: UnvalidatedType?, val expression: AmbiguousExpression, val nameLocation: Location?)
+data class Assignment(val name: String, val type: UnvalidatedType?, val expression: Expression, val nameLocation: Location?)
 data class ValidatedAssignment(val name: String, val type: Type, val expression: TypedExpression)
-data class UnvalidatedArgument(val name: String, val type: Type, val location: Location?)
+data class UnvalidatedArgument(val name: String, val type: UnvalidatedType, val location: Location?)
 data class Argument(val name: String, val type: Type)
 data class AmbiguousBlock(val assignments: List<AmbiguousAssignment>, val returnedExpression: AmbiguousExpression, val location: Location?)
 data class Block(val assignments: List<Assignment>, val returnedExpression: Expression, val location: Location?)
 data class TypedBlock(val type: Type, val assignments: List<ValidatedAssignment>, val returnedExpression: TypedExpression)
-data class Function(override val id: EntityId, val typeParameters: List<String>, val arguments: List<UnvalidatedArgument>, val returnType: Type, val block: Block, override val annotations: List<Annotation>, val idLocation: Location?, val returnTypeLocation: Location?) : TopLevelEntity {
-    fun getTypeSignature(): TypeSignature {
-        return TypeSignature(id,
+data class Function(override val id: EntityId, val typeParameters: List<String>, val arguments: List<UnvalidatedArgument>, val returnType: UnvalidatedType, val block: Block, override val annotations: List<Annotation>, val idLocation: Location?, val returnTypeLocation: Location?) : TopLevelEntity {
+    fun getTypeSignature(): UnvalidatedTypeSignature {
+        return UnvalidatedTypeSignature(id,
                 arguments.map(UnvalidatedArgument::type),
                 returnType,
-                typeParameters.map { str -> Type.NamedType.forParameter(str) })
+                typeParameters)
     }
 }
 data class ValidatedFunction(override val id: EntityId, val typeParameters: List<String>, val arguments: List<Argument>, val returnType: Type, val block: TypedBlock, override val annotations: List<Annotation>) : TopLevelEntity {
@@ -382,37 +426,42 @@ data class ValidatedFunction(override val id: EntityId, val typeParameters: List
         return TypeSignature(id,
                 arguments.map(Argument::type),
                 returnType,
-                typeParameters.map { str -> Type.NamedType.forParameter(str) })
+                typeParameters)
     }
 }
 
-data class UnvalidatedStruct(override val id: EntityId, val typeParameters: List<String>, val members: List<Member>, val requires: Block?, override val annotations: List<Annotation>, val idLocation: Location?) : TopLevelEntity {
-    fun getConstructorSignature(): TypeSignature {
-        val argumentTypes = members.map(Member::type)
-        val typeParameters = typeParameters.map(Type.NamedType.Companion::forParameter)
+data class UnvalidatedStruct(override val id: EntityId, val typeParameters: List<String>, val members: List<UnvalidatedMember>, val requires: Block?, override val annotations: List<Annotation>, val idLocation: Location?) : TopLevelEntity {
+    fun getConstructorSignature(): UnvalidatedTypeSignature {
+        val argumentTypes = members.map(UnvalidatedMember::type)
+        val typeParameters = typeParameters.map(UnvalidatedType.NamedType.Companion::forParameter)
         val outputType = if (requires == null) {
-            Type.NamedType(id.asRef(), typeParameters)
+            UnvalidatedType.NamedType(id.asRef(), typeParameters)
         } else {
-            Type.Try(Type.NamedType(id.asRef(), typeParameters))
+            UnvalidatedType.Try(UnvalidatedType.NamedType(id.asRef(), typeParameters))
         }
-        return TypeSignature(id, argumentTypes, outputType, typeParameters)
+        return UnvalidatedTypeSignature(id, argumentTypes, outputType, this.typeParameters)
     }
 }
-data class Struct(override val id: EntityId, val typeParameters: List<String>, val members: List<Member>, val requires: TypedBlock?, override val annotations: List<Annotation>) : TopLevelEntity {
+data class Struct(override val id: EntityId, val moduleId: ModuleId, val typeParameters: List<String>, val members: List<Member>, val requires: TypedBlock?, override val annotations: List<Annotation>) : TopLevelEntity {
+    val resolvedRef = ResolvedEntityRef(moduleId, id)
     fun getIndexForName(name: String): Int {
         return members.indexOfFirst { member -> member.name == name }
+    }
+
+    fun getType(): Type.NamedType {
+        return Type.NamedType(resolvedRef, id.asRef(), typeParameters.map(Type::ParameterType))
     }
 
     // TODO: Deconflict with UnvalidatedStruct version
     fun getConstructorSignature(): TypeSignature {
         val argumentTypes = members.map(Member::type)
-        val typeParameters = typeParameters.map(Type.NamedType.Companion::forParameter)
+        val typeParameters = typeParameters.map(Type::ParameterType)
         val outputType = if (requires == null) {
-            Type.NamedType(id.asRef(), typeParameters)
+            Type.NamedType(resolvedRef, id.asRef(), typeParameters)
         } else {
-            Type.Try(Type.NamedType(id.asRef(), typeParameters))
+            Type.Try(Type.NamedType(resolvedRef, id.asRef(), typeParameters))
         }
-        return TypeSignature(id, argumentTypes, outputType, typeParameters)
+        return TypeSignature(id, argumentTypes, outputType, this.typeParameters)
     }
 }
 interface HasId {
@@ -421,64 +470,65 @@ interface HasId {
 interface TopLevelEntity: HasId {
     val annotations: List<Annotation>
 }
+data class UnvalidatedMember(val name: String, val type: UnvalidatedType)
 data class Member(val name: String, val type: Type)
 
 data class UnvalidatedInterface(override val id: EntityId, val typeParameters: List<String>, val methods: List<UnvalidatedMethod>, override val annotations: List<Annotation>, val idLocation: Location?) : TopLevelEntity {
     val adapterId: EntityId = getAdapterIdForInterfaceId(id)
     val dataTypeParameter = getUnusedTypeParameterName(typeParameters)
-    val dataType = Type.NamedType.forParameter(dataTypeParameter)
+    val dataType = UnvalidatedType.NamedType.forParameter(dataTypeParameter)
     fun getAdapterStruct(): UnvalidatedStruct {
         val members = methods.map { method ->
             val methodType = method.functionType
-            Member(method.name, Type.FunctionType(listOf(dataType) + methodType.argTypes, methodType.outputType))
+            UnvalidatedMember(method.name, UnvalidatedType.FunctionType(listOf(dataType) + methodType.argTypes, methodType.outputType))
         }
         return UnvalidatedStruct(adapterId, listOf(dataTypeParameter) + typeParameters,
                 members, null, listOf(), idLocation)
     }
 
-    fun getInstanceConstructorSignature(): TypeSignature {
+    fun getInstanceConstructorSignature(): UnvalidatedTypeSignature {
         val explicitTypeParameters = this.typeParameters
         val allTypeParameters = this.getAdapterStruct().typeParameters
         val dataTypeParameter = allTypeParameters[0]
 
-        val argumentTypes = ArrayList<Type>()
-        val dataStructType = Type.NamedType.forParameter(dataTypeParameter)
+        val argumentTypes = ArrayList<UnvalidatedType>()
+        val dataStructType = UnvalidatedType.NamedType.forParameter(dataTypeParameter)
         argumentTypes.add(dataStructType)
 
-        val adapterType = Type.NamedType(this.adapterId.asRef(), allTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val adapterType = UnvalidatedType.NamedType(this.adapterId.asRef(), allTypeParameters.map { name -> UnvalidatedType.NamedType.forParameter(name) })
         argumentTypes.add(adapterType)
 
-        val outputType = Type.NamedType(this.id.asRef(), explicitTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val outputType = UnvalidatedType.NamedType(this.id.asRef(), explicitTypeParameters.map { name -> UnvalidatedType.NamedType.forParameter(name) })
 
-        return TypeSignature(this.id, argumentTypes, outputType, allTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        return UnvalidatedTypeSignature(this.id, argumentTypes, outputType, allTypeParameters)
     }
-    fun getAdapterConstructorSignature(): TypeSignature {
+    fun getAdapterConstructorSignature(): UnvalidatedTypeSignature {
         val adapterTypeParameters = this.getAdapterStruct().typeParameters
-        val dataStructType = Type.NamedType.forParameter(adapterTypeParameters[0])
+        val dataStructType = UnvalidatedType.NamedType.forParameter(adapterTypeParameters[0])
 
-        val argumentTypes = ArrayList<Type>()
+        val argumentTypes = ArrayList<UnvalidatedType>()
         this.methods.forEach { method ->
             argumentTypes.add(getInterfaceMethodReferenceType(dataStructType, method))
         }
 
-        val outputType = Type.NamedType(this.adapterId.asRef(), adapterTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val outputType = UnvalidatedType.NamedType(this.adapterId.asRef(), adapterTypeParameters.map { name -> UnvalidatedType.NamedType.forParameter(name) })
 
-        return TypeSignature(this.adapterId, argumentTypes, outputType, adapterTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        return UnvalidatedTypeSignature(this.adapterId, argumentTypes, outputType, adapterTypeParameters)
     }
 }
-data class Interface(override val id: EntityId, val typeParameters: List<String>, val methods: List<Method>, override val annotations: List<Annotation>) : TopLevelEntity {
+data class Interface(override val id: EntityId, val moduleId: ModuleId, val typeParameters: List<String>, val methods: List<Method>, override val annotations: List<Annotation>) : TopLevelEntity {
     fun getIndexForName(name: String): Int {
         return methods.indexOfFirst { method -> method.name == name }
     }
     val adapterId: EntityId = getAdapterIdForInterfaceId(id)
     val dataTypeParameter = getUnusedTypeParameterName(typeParameters)
-    val dataType = Type.NamedType.forParameter(dataTypeParameter)
+    val dataType = Type.ParameterType(dataTypeParameter)
     fun getAdapterStruct(): Struct {
         val members = methods.map { method ->
             val methodType = method.functionType
             Member(method.name, Type.FunctionType(listOf(dataType) + methodType.argTypes, methodType.outputType))
         }
-        return Struct(adapterId, listOf(dataTypeParameter) + typeParameters,
+        return Struct(adapterId, moduleId, listOf(dataTypeParameter) + typeParameters,
                 members, null, listOf())
     }
 
@@ -488,32 +538,32 @@ data class Interface(override val id: EntityId, val typeParameters: List<String>
         val dataTypeParameter = allTypeParameters[0]
 
         val argumentTypes = ArrayList<Type>()
-        val dataStructType = Type.NamedType.forParameter(dataTypeParameter)
+        val dataStructType = Type.ParameterType(dataTypeParameter)
         argumentTypes.add(dataStructType)
 
-        val adapterType = Type.NamedType(this.adapterId.asRef(), allTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val adapterType = Type.NamedType(ResolvedEntityRef(moduleId, this.adapterId), this.adapterId.asRef(), allTypeParameters.map { name -> Type.ParameterType(name) })
         argumentTypes.add(adapterType)
 
-        val outputType = Type.NamedType(this.id.asRef(), explicitTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val outputType = Type.NamedType(ResolvedEntityRef(moduleId, this.id), this.id.asRef(), explicitTypeParameters.map { name -> Type.ParameterType(name) })
 
-        return TypeSignature(this.id, argumentTypes, outputType, allTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        return TypeSignature(this.id, argumentTypes, outputType, allTypeParameters)
     }
     fun getAdapterConstructorSignature(): TypeSignature {
         val adapterTypeParameters = this.getAdapterStruct().typeParameters
-        val dataStructType = Type.NamedType.forParameter(adapterTypeParameters[0])
+        val dataStructType = Type.ParameterType(adapterTypeParameters[0])
 
         val argumentTypes = ArrayList<Type>()
         this.methods.forEach { method ->
             argumentTypes.add(getInterfaceMethodReferenceType(dataStructType, method))
         }
 
-        val outputType = Type.NamedType(this.adapterId.asRef(), adapterTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        val outputType = Type.NamedType(ResolvedEntityRef(moduleId, this.adapterId), this.adapterId.asRef(), adapterTypeParameters.map { name -> Type.ParameterType(name) })
 
-        return TypeSignature(this.adapterId, argumentTypes, outputType, adapterTypeParameters.map { name -> Type.NamedType.forParameter(name) })
+        return TypeSignature(this.adapterId, argumentTypes, outputType, adapterTypeParameters)
     }
 }
-data class UnvalidatedMethod(val name: String, val typeParameters: List<String>, val arguments: List<UnvalidatedArgument>, val returnType: Type) {
-    val functionType = Type.FunctionType(arguments.map { arg -> arg.type }, returnType)
+data class UnvalidatedMethod(val name: String, val typeParameters: List<String>, val arguments: List<UnvalidatedArgument>, val returnType: UnvalidatedType) {
+    val functionType = UnvalidatedType.FunctionType(arguments.map { arg -> arg.type }, returnType)
 }
 data class Method(val name: String, val typeParameters: List<String>, val arguments: List<Argument>, val returnType: Type) {
     val functionType = Type.FunctionType(arguments.map { arg -> arg.type }, returnType)
@@ -533,16 +583,16 @@ private fun getUnusedTypeParameterName(explicitTypeParameters: List<String>): St
     }
 }
 
-private fun getInterfaceMethodReferenceType(intrinsicStructType: Type.NamedType, method: UnvalidatedMethod): Type {
-    val argTypes = ArrayList<Type>()
+private fun getInterfaceMethodReferenceType(intrinsicStructType: UnvalidatedType.NamedType, method: UnvalidatedMethod): UnvalidatedType {
+    val argTypes = ArrayList<UnvalidatedType>()
     argTypes.add(intrinsicStructType)
     method.arguments.forEach { argument ->
         argTypes.add(argument.type)
     }
 
-    return Type.FunctionType(argTypes, method.returnType)
+    return UnvalidatedType.FunctionType(argTypes, method.returnType)
 }
-private fun getInterfaceMethodReferenceType(intrinsicStructType: Type.NamedType, method: Method): Type {
+private fun getInterfaceMethodReferenceType(intrinsicStructType: Type.ParameterType, method: Method): Type {
     val argTypes = ArrayList<Type>()
     argTypes.add(intrinsicStructType)
     method.arguments.forEach { argument ->

--- a/kotlin/semlang-api/src/main/kotlin/net/semlang/api/module.kt
+++ b/kotlin/semlang-api/src/main/kotlin/net/semlang/api/module.kt
@@ -343,6 +343,10 @@ class ValidatedModule private constructor(val id: ModuleId,
         return resolver.resolve(ref)
     }
 
+    fun resolve(ref: ResolvedEntityRef): EntityResolution? {
+        return resolver.resolve(EntityRef(ref.module.asRef(), ref.id))
+    }
+
 }
 
 enum class FunctionLikeType {

--- a/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
+++ b/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
@@ -294,6 +294,7 @@ object NativeStruct {
             TypedBlock(Type.BOOLEAN, listOf(), TypedExpression.NamedFunctionCall(
                     Type.BOOLEAN,
                     EntityRef.of("Natural", "lessThan"),
+                    ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Natural", "lessThan")),
                     listOf(TypedExpression.Variable(Type.NATURAL, "natural"),
                             TypedExpression.Literal(Type.NATURAL, "1114112")),
                     listOf()
@@ -319,15 +320,18 @@ object NativeStruct {
             TypedBlock(Type.BOOLEAN, listOf(), TypedExpression.NamedFunctionCall(
                     Type.BOOLEAN,
                     EntityRef.of("Boolean", "or"),
+                    ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Boolean", "or")),
                     listOf(TypedExpression.NamedFunctionCall(
                             Type.BOOLEAN,
                             EntityRef.of("Natural", "equals"),
+                            ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Natural", "equals")),
                             listOf(TypedExpression.Variable(Type.NATURAL, "natural"),
                                     TypedExpression.Literal(Type.NATURAL, "0")),
                             listOf()
                         ), TypedExpression.NamedFunctionCall(
                             Type.BOOLEAN,
                             EntityRef.of("Natural", "equals"),
+                            ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Natural", "equals")),
                             listOf(TypedExpression.Variable(Type.NATURAL, "natural"),
                                     TypedExpression.Literal(Type.NATURAL, "1")),
                             listOf()

--- a/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
+++ b/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
@@ -250,8 +250,7 @@ private fun addTryFunctions(definitions: ArrayList<TypeSignature>) {
 private fun addSequenceFunctions(definitions: ArrayList<TypeSignature>) {
     val paramT = Type.ParameterType("T")
 
-    val sequenceT = Type.NamedType(ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Sequence")), EntityRef.of("Sequence"), listOf(paramT))
-//    val sequenceT = Type.NamedType(NativeInterface.SEQUENCE.resolvedRef, listOf(paramT))
+    val sequenceT = NativeInterface.SEQUENCE.getType()
 
     // Sequence.create
     // TODO: This should be library code in semlang in most cases, not native

--- a/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
+++ b/kotlin/semlang-api/src/main/kotlin/net/semlang/api/nativeFunctions.kt
@@ -132,11 +132,11 @@ private fun addNaturalFunctions(definitions: ArrayList<TypeSignature>) {
     // Natural.bitwiseAnd
     definitions.add(TypeSignature(EntityId.of("Natural", "bitwiseAnd"), listOf(Type.NATURAL, Type.NATURAL), Type.NATURAL))
     // Natural.toBits
-    definitions.add(TypeSignature(EntityId.of("Natural", "toBits"), listOf(Type.NATURAL), Type.NamedType(NativeStruct.BITS_BIG_ENDIAN.id.asRef())))
+    definitions.add(TypeSignature(EntityId.of("Natural", "toBits"), listOf(Type.NATURAL), NativeStruct.BITS_BIG_ENDIAN.getType()))
     // Natural.toNBits
-    definitions.add(TypeSignature(EntityId.of("Natural", "toNBits"), listOf(Type.NATURAL, Type.NATURAL), Type.Try(Type.NamedType(NativeStruct.BITS_BIG_ENDIAN.id.asRef()))))
+    definitions.add(TypeSignature(EntityId.of("Natural", "toNBits"), listOf(Type.NATURAL, Type.NATURAL), Type.Try(NativeStruct.BITS_BIG_ENDIAN.getType())))
     // Natural.fromBits
-    definitions.add(TypeSignature(EntityId.of("Natural", "fromBits"), listOf(Type.NamedType(NativeStruct.BITS_BIG_ENDIAN.id.asRef())), Type.NATURAL))
+    definitions.add(TypeSignature(EntityId.of("Natural", "fromBits"), listOf(NativeStruct.BITS_BIG_ENDIAN.getType()), Type.NATURAL))
 
     // Natural.max
     definitions.add(TypeSignature(EntityId.of("Natural", "max"), listOf(Type.List(Type.NATURAL)), Type.Try(Type.NATURAL)))
@@ -151,110 +151,111 @@ private fun addNaturalFunctions(definitions: ArrayList<TypeSignature>) {
 }
 
 private fun addListFunctions(definitions: ArrayList<TypeSignature>) {
-    val paramT = Type.NamedType.forParameter("T")
-    val paramU = Type.NamedType.forParameter("U")
+    val paramT = Type.ParameterType("T")
+    val paramU = Type.ParameterType("U")
 
     // List.append
-    definitions.add(TypeSignature(EntityId.of("List", "append"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "append"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), paramT),
             outputType = Type.List(paramT)))
 
     // List.appendFront
-    definitions.add(TypeSignature(EntityId.of("List", "appendFront"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "appendFront"), typeParameters = listOf("T"),
             argumentTypes = listOf(paramT, Type.List(paramT)),
             outputType = Type.List(paramT)))
 
     // List.concatenate
-    definitions.add(TypeSignature(EntityId.of("List", "concatenate"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "concatenate"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), Type.List(paramT)),
             outputType = Type.List(paramT)))
 
     // List.drop
-    definitions.add(TypeSignature(EntityId.of("List", "drop"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "drop"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), Type.NATURAL),
             outputType = Type.List(paramT)))
 
     // TODO: Semantics of this are arguably different from last()... but I kind of like it that way
     // List.lastN
-    definitions.add(TypeSignature(EntityId.of("List", "lastN"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "lastN"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), Type.NATURAL),
             outputType = Type.List(paramT)))
 
     // List.map
-    definitions.add(TypeSignature(EntityId.of("List", "map"), typeParameters = listOf(paramT, paramU),
+    definitions.add(TypeSignature(EntityId.of("List", "map"), typeParameters = listOf("T", "U"),
             argumentTypes = listOf(Type.List(paramT), Type.FunctionType(listOf(paramT), paramU)),
             outputType = Type.List(paramU)))
 
     // List.filter
-    definitions.add(TypeSignature(EntityId.of("List", "filter"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "filter"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), Type.FunctionType(listOf(paramT), Type.BOOLEAN)),
             outputType = Type.List(paramT)))
 
     // List.reduce
-    definitions.add(TypeSignature(EntityId.of("List", "reduce"), typeParameters = listOf(paramT, paramU),
+    definitions.add(TypeSignature(EntityId.of("List", "reduce"), typeParameters = listOf("T", "U"),
             argumentTypes = listOf(Type.List(paramT), paramU, Type.FunctionType(listOf(paramU, paramT), paramU)),
             outputType = paramU))
 
     // List.size
-    definitions.add(TypeSignature(EntityId.of("List", "size"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "size"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT)),
             outputType = Type.NATURAL))
 
     // List.get
-    definitions.add(TypeSignature(EntityId.of("List", "get"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "get"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT), Type.NATURAL),
             outputType = Type.Try(paramT)))
 
     // List.first TODO: To library
-    definitions.add(TypeSignature(EntityId.of("List", "first"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "first"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT)),
             outputType = Type.Try(paramT)))
 
     // List.last TODO: To library
-    definitions.add(TypeSignature(EntityId.of("List", "last"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("List", "last"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.List(paramT)),
             outputType = Type.Try(paramT)))
 }
 
 private fun addTryFunctions(definitions: ArrayList<TypeSignature>) {
-    val paramT = Type.NamedType.forParameter("T")
-    val paramU = Type.NamedType.forParameter("U")
+    val paramT = Type.ParameterType("T")
+    val paramU = Type.ParameterType("U")
 
     // Try.success
-    definitions.add(TypeSignature(EntityId.of("Try", "success"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("Try", "success"), typeParameters = listOf("T"),
             argumentTypes = listOf(paramT),
             outputType = Type.Try(paramT)))
 
     // Try.failure
-    definitions.add(TypeSignature(EntityId.of("Try", "failure"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("Try", "failure"), typeParameters = listOf("T"),
             argumentTypes = listOf(),
             outputType = Type.Try(paramT)))
 
     // Try.assume
-    definitions.add(TypeSignature(EntityId.of("Try", "assume"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("Try", "assume"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.Try(paramT)),
             outputType = paramT))
 
 
     // Try.isSuccess
-    definitions.add(TypeSignature(EntityId.of("Try", "isSuccess"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("Try", "isSuccess"), typeParameters = listOf("T"),
             argumentTypes = listOf(Type.Try(paramT)),
             outputType = Type.BOOLEAN))
 
     // Try.map
-    definitions.add(TypeSignature(EntityId.of("Try", "map"), typeParameters = listOf(paramT, paramU),
+    definitions.add(TypeSignature(EntityId.of("Try", "map"), typeParameters = listOf("T", "U"),
             argumentTypes = listOf(Type.Try(paramT), Type.FunctionType(listOf(paramT), paramU)),
             outputType = Type.Try(paramU)))
 }
 
 private fun addSequenceFunctions(definitions: ArrayList<TypeSignature>) {
-    val paramT = Type.NamedType.forParameter("T")
+    val paramT = Type.ParameterType("T")
 
-    val sequenceT = Type.NamedType(EntityRef.of("Sequence"), listOf(paramT))
+    val sequenceT = Type.NamedType(ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("Sequence")), EntityRef.of("Sequence"), listOf(paramT))
+//    val sequenceT = Type.NamedType(NativeInterface.SEQUENCE.resolvedRef, listOf(paramT))
 
     // Sequence.create
     // TODO: This should be library code in semlang in most cases, not native
-    definitions.add(TypeSignature(EntityId.of("Sequence", "create"), typeParameters = listOf(paramT),
+    definitions.add(TypeSignature(EntityId.of("Sequence", "create"), typeParameters = listOf("T"),
             argumentTypes = listOf(paramT, Type.FunctionType(listOf(paramT), paramT)),
             outputType = sequenceT))
 
@@ -262,7 +263,7 @@ private fun addSequenceFunctions(definitions: ArrayList<TypeSignature>) {
 }
 
 private fun addStringFunctions(definitions: ArrayList<TypeSignature>) {
-    val stringType = Type.NamedType(EntityRef.of("Unicode", "String"))
+    val stringType = NativeStruct.UNICODE_STRING.getType()
 
     // Unicode.String.length
     // TODO: Limit output to 32-bit type
@@ -272,10 +273,11 @@ private fun addStringFunctions(definitions: ArrayList<TypeSignature>) {
 }
 
 object NativeStruct {
-    private val typeT = Type.NamedType.forParameter("T")
-    private val typeU = Type.NamedType.forParameter("U")
+    private val typeT = Type.ParameterType("T")
+    private val typeU = Type.ParameterType("U")
     val BASIC_SEQUENCE = Struct(
             EntityId.of("BasicSequence"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf("T"),
             listOf(
                     Member("base", typeT),
@@ -286,6 +288,7 @@ object NativeStruct {
     )
     val UNICODE_CODE_POINT = Struct(
             EntityId.of("Unicode", "CodePoint"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf(),
             listOf(
                     Member("natural", Type.NATURAL)
@@ -303,15 +306,17 @@ object NativeStruct {
     )
     val UNICODE_STRING = Struct(
             EntityId.of("Unicode", "String"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf(),
             listOf(
-                    Member("codePoints", Type.List(Type.NamedType(UNICODE_CODE_POINT.id.asRef())))
+                    Member("codePoints", Type.List(UNICODE_CODE_POINT.getType()))
             ),
             null,
             listOf()
     )
     val BIT = Struct(
             EntityId.of("Bit"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf(),
             listOf(
                     Member("natural", Type.NATURAL)
@@ -343,9 +348,10 @@ object NativeStruct {
     )
     val BITS_BIG_ENDIAN = Struct(
             EntityId.of("BitsBigEndian"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf(),
             listOf(
-                    Member("bits", Type.List(Type.NamedType(BIT.id.asRef())))
+                    Member("bits", Type.List(BIT.getType()))
             ),
             null,
             listOf()
@@ -365,9 +371,10 @@ fun getNativeStructs(): Map<EntityId, Struct> {
 }
 
 object NativeInterface {
-    private val typeT = Type.NamedType.forParameter("T")
+    private val typeT = Type.ParameterType("T")
     val SEQUENCE = Interface(
             EntityId.of("Sequence"),
+            CURRENT_NATIVE_MODULE_ID,
             listOf("T"),
             listOf(
                     Method("get", listOf(), listOf(Argument("index", Type.NATURAL)), typeT),

--- a/kotlin/semlang-api/src/test/kotlin/net/semlang/api/test/moduleTests.kt
+++ b/kotlin/semlang-api/src/test/kotlin/net/semlang/api/test/moduleTests.kt
@@ -60,36 +60,37 @@ class ContextTests {
                 { module, id -> module.getExportedInterface(id)?.interfac })
     }
 
-    fun <T> testEntityVisibility(createEntity: (id: EntityId, uniqueAspect: Int, exported: Boolean) -> T,
+    fun <T> testEntityVisibility(createEntity: (id: EntityId, moduleId: ModuleId, uniqueAspect: Int, exported: Boolean) -> T,
                                  createModule: (moduleId: ModuleId, entities: Map<EntityId, T>, upstreamModules: List<ValidatedModule>) -> ValidatedModule,
                                  getInternalEntity: (module: ValidatedModule, id: EntityId) -> T?,
                                  getExportedEntity: (module: ValidatedModule, id: EntityId) -> T?) {
+        val upstreamModuleId = ModuleId("example", "upstream", "0.1")
+        val downstreamModuleId = ModuleId("example", "downstream", "0.1")
+
         val coincidentallySharedInternalId = EntityId.of("coincidentallySharedInternal")
-        val upstreamEntityWithSharedId = createEntity(coincidentallySharedInternalId, 1, false)
-        val downstreamEntityWithSharedId = createEntity(coincidentallySharedInternalId, 2, false)
+        val upstreamEntityWithSharedId = createEntity(coincidentallySharedInternalId, upstreamModuleId, 1, false)
+        val downstreamEntityWithSharedId = createEntity(coincidentallySharedInternalId, downstreamModuleId, 2, false)
 
         val upstreamInternalId = EntityId.of("upstreamInternal")
-        val upstreamInternalEntity = createEntity(upstreamInternalId, 3, false)
+        val upstreamInternalEntity = createEntity(upstreamInternalId, upstreamModuleId, 3, false)
 
         val upstreamExportedId = EntityId.of("upstreamExported")
-        val upstreamExportedEntity = createEntity(upstreamExportedId, 4, true)
+        val upstreamExportedEntity = createEntity(upstreamExportedId, upstreamModuleId, 4, true)
 
         val upstreamEntities = mapOf(upstreamInternalId to upstreamInternalEntity,
                 upstreamExportedId to upstreamExportedEntity,
                 coincidentallySharedInternalId to upstreamEntityWithSharedId)
 
         val downstreamInternalId = EntityId.of("downstreamInternal")
-        val downstreamInternalEntity = createEntity(downstreamInternalId, 5, false)
+        val downstreamInternalEntity = createEntity(downstreamInternalId, downstreamModuleId, 5, false)
 
         val downstreamExportedId = EntityId.of("downstreamExported")
-        val downstreamExportedEntity = createEntity(downstreamExportedId, 6, true)
+        val downstreamExportedEntity = createEntity(downstreamExportedId, downstreamModuleId, 6, true)
 
         val downstreamEntities = mapOf(downstreamInternalId to downstreamInternalEntity,
                 downstreamExportedId to downstreamExportedEntity,
                 coincidentallySharedInternalId to downstreamEntityWithSharedId)
 
-        val upstreamModuleId = ModuleId("example", "upstream", "0.1")
-        val downstreamModuleId = ModuleId("example", "downstream", "0.1")
         val upstreamContext = createModule(upstreamModuleId, upstreamEntities, listOf())
         val downstreamContext = createModule(downstreamModuleId, downstreamEntities, listOf(upstreamContext))
 
@@ -118,7 +119,7 @@ class ContextTests {
     }
 }
 
-private fun createFunctionWithId(id: EntityId, uniqueAspect: Int, exported: Boolean): ValidatedFunction {
+private fun createFunctionWithId(id: EntityId, moduleId: ModuleId, uniqueAspect: Int, exported: Boolean): ValidatedFunction {
     val block = TypedBlock(Type.INTEGER, listOf(), TypedExpression.Literal(Type.INTEGER, uniqueAspect.toString()))
     val annotations = if (exported) {
         listOf(Annotation("Exported", listOf()))
@@ -128,22 +129,22 @@ private fun createFunctionWithId(id: EntityId, uniqueAspect: Int, exported: Bool
     return ValidatedFunction(id, listOf(), listOf(), Type.INTEGER, block, annotations)
 }
 
-private fun createStructWithId(id: EntityId, uniqueAspect: Int, exported: Boolean): Struct {
+private fun createStructWithId(id: EntityId, moduleId: ModuleId, uniqueAspect: Int, exported: Boolean): Struct {
     val member = Member(uniqueAspect.toString(), Type.INTEGER)
     val annotations = if (exported) {
         listOf(Annotation("Exported", listOf()))
     } else {
         listOf()
     }
-    return Struct(id, listOf(), listOf(member), null, annotations)
+    return Struct(id, moduleId, listOf(), listOf(member), null, annotations)
 }
 
-private fun createInterfaceWithId(id: EntityId, uniqueAspect: Int, exported: Boolean): Interface {
+private fun createInterfaceWithId(id: EntityId, moduleId: ModuleId, uniqueAspect: Int, exported: Boolean): Interface {
     val method = Method(uniqueAspect.toString(), listOf(), listOf(), Type.INTEGER)
     val annotations = if (exported) {
         listOf(Annotation("Exported", listOf()))
     } else {
         listOf()
     }
-    return Interface(id, listOf(), listOf(method), annotations)
+    return Interface(id, moduleId, listOf(), listOf(method), annotations)
 }

--- a/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/NativeFunctions.kt
+++ b/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/NativeFunctions.kt
@@ -494,7 +494,7 @@ private fun addTryFunctions(list: MutableList<NativeFunction>) {
 private fun addSequenceFunctions(list: MutableList<NativeFunction>) {
     val sequenceDot = fun(name: String) = EntityId.of("Sequence", name)
 
-    val basicSequenceDot = fun(name: String) = EntityId.of("BasicSequence", name)
+    val basicSequenceDot = fun(name: String) = ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, EntityId.of("BasicSequence", name))
 
     // Sequence.create
     list.add(NativeFunction(sequenceDot("create"), { args: List<SemObject>, _: InterpreterCallback ->
@@ -511,7 +511,7 @@ private fun addSequenceFunctions(list: MutableList<NativeFunction>) {
     }))
 
     // BasicSequence.get(BasicSequence, index)
-    list.add(NativeFunction(basicSequenceDot("get"), { args: List<SemObject>, apply: InterpreterCallback ->
+    list.add(NativeFunction(EntityId.of("BasicSequence", "get"), { args: List<SemObject>, apply: InterpreterCallback ->
         val sequence = args[0] as? SemObject.Struct ?: typeError()
         val index = args[1] as? SemObject.Natural ?: typeError()
         if (sequence.struct.id != NativeStruct.BASIC_SEQUENCE.id) {
@@ -528,7 +528,7 @@ private fun addSequenceFunctions(list: MutableList<NativeFunction>) {
     }))
 
     // BasicSequence.first
-    list.add(NativeFunction(basicSequenceDot("first"), BasicSequenceFirst@ { args: List<SemObject>, apply: InterpreterCallback ->
+    list.add(NativeFunction(EntityId.of("BasicSequence", "first"), BasicSequenceFirst@ { args: List<SemObject>, apply: InterpreterCallback ->
         val sequence = args[0] as? SemObject.Struct ?: typeError()
         val predicate = args[1] as? SemObject.FunctionBinding ?: typeError()
         if (sequence.struct.id != NativeStruct.BASIC_SEQUENCE.id) {

--- a/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemObject.kt
+++ b/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemObject.kt
@@ -43,6 +43,6 @@ sealed class SemObject {
 }
 
 sealed class FunctionBindingTarget {
-    data class Named(val functionId: EntityId): FunctionBindingTarget()
+    data class Named(val functionRef: ResolvedEntityRef): FunctionBindingTarget()
     data class Inline(val functionDef: TypedExpression.InlineFunction): FunctionBindingTarget()
 }

--- a/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemlangInterpreter.kt
+++ b/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemlangInterpreter.kt
@@ -343,11 +343,12 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
             is Type.Try -> evaluateTryLiteral(type, literal)
             is Type.FunctionType -> throw IllegalArgumentException("Unhandled literal \"$literal\" of type $type")
             is Type.NamedType -> evaluateNamedLiteral(type, literal)
+            is Type.ParameterType -> throw IllegalArgumentException("Unhandled literal \"$literal\" of type $type")
         }
     }
 
     private fun evaluateNamedLiteral(type: Type.NamedType, literal: String): SemObject {
-        if (type.ref.moduleRef == null && type.ref.id == NativeStruct.UNICODE_STRING.id) {
+        if (isNativeModule(type.ref.module) && type.ref.id == NativeStruct.UNICODE_STRING.id) {
             // TODO: Check for errors related to string encodings
             return evaluateStringLiteral(literal)
         }

--- a/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemlangInterpreter.kt
+++ b/kotlin/semlang-interpreter/src/main/kotlin/net/semlang/interpreter/SemlangInterpreter.kt
@@ -13,7 +13,7 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
     private val nativeFunctions: Map<EntityId, NativeFunction> = getNativeFunctions()
 
     override fun interpret(functionId: EntityId, arguments: List<SemObject>): SemObject {
-        return interpret(EntityRef(mainModule.id.asRef(), functionId), arguments, mainModule)
+        return interpret(ResolvedEntityRef(mainModule.id, functionId), arguments, mainModule)
     }
 
     /**
@@ -21,13 +21,14 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
      * actually evaluated, we'll need to use the "containing module", i.e. the module where that code
      * was written.
      */
-    private fun interpret(functionRef: EntityRef, arguments: List<SemObject>, referringModule: ValidatedModule?): SemObject {
+    private fun interpret(functionRef: ResolvedEntityRef, arguments: List<SemObject>, referringModule: ValidatedModule?): SemObject {
         try {
             if (referringModule == null) {
                 return interpretNative(functionRef, arguments)
             }
 
             // TODO: Have one of these for native stuff, as well
+            // TODO: We already have the reference here but not the FunctionLikeType. Should we store that in language objects as well?
             val entityResolution = referringModule.resolve(functionRef) ?: error("The function $functionRef isn't recognized")
 
             when (entityResolution.type) {
@@ -80,7 +81,7 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
         error("I don't know what to do with the module $id from the referring module $referringModule")
     }
 
-    private fun interpretNative(ref: EntityRef, arguments: List<SemObject>): SemObject {
+    private fun interpretNative(ref: ResolvedEntityRef, arguments: List<SemObject>): SemObject {
         // TODO: Better approach to figuring out the type of thing here (i.e. a TypeResolver just for native stuff)
         assertModuleRefConsistentWithNative(ref)
 
@@ -108,29 +109,23 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
         error("Unrecognized entity $ref")
     }
 
-    private fun assertModuleRefConsistentWithNative(entityRef: EntityRef) {
-        val moduleRef = entityRef.moduleRef
-        if (moduleRef != null) {
-            if (moduleRef.module != NATIVE_MODULE_NAME
-                    || (moduleRef.group != null && moduleRef.group != NATIVE_MODULE_GROUP)) {
-                error("We're trying to evaluate ${entityRef} like a native entity, but its module ref is not consistent with the native package")
-            }
+    private fun assertModuleRefConsistentWithNative(entityRef: ResolvedEntityRef) {
+        val moduleId = entityRef.module
+        if (!isNativeModule(moduleId)) {
+            error("We're trying to evaluate ${entityRef} like a native entity, but its module ref is not consistent with the native package")
         }
     }
 
     private fun interpretBinding(functionBinding: SemObject.FunctionBinding, args: List<SemObject>): SemObject {
-        // TODO: Ideally this would be a ResolvedEntityRef, which would then give us the module?
-        // (I guess ResolvedEntityRef needs to deal with the possibility of the native module)
         val target = functionBinding.target
         return when (target) {
             is FunctionBindingTarget.Named -> {
-                val functionRef = EntityRef(functionBinding.containingModule?.id?.asRef(), target.functionId)
                 val containingModule = functionBinding.containingModule
 
                 val argsItr = args.iterator()
                 val fullArguments = functionBinding.bindings.map { it ?: argsItr.next() }
 
-                return interpret(functionRef, fullArguments, containingModule)
+                return interpret(target.functionRef, fullArguments, containingModule)
             }
             is FunctionBindingTarget.Inline -> {
                 val argsItr = args.iterator()
@@ -276,7 +271,7 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
             }
             is TypedExpression.NamedFunctionCall -> {
                 val arguments = expression.arguments.map { argExpr -> evaluateExpression(argExpr, assignments, containingModule) }
-                return interpret(expression.functionRef, arguments, containingModule)
+                return interpret(expression.resolvedFunctionRef, arguments, containingModule)
             }
             is TypedExpression.Literal -> {
                 return evaluateLiteral(expression.type, expression.literal)
@@ -286,16 +281,15 @@ class SemlangForwardInterpreter(val mainModule: ValidatedModule): SemlangInterpr
                 return SemObject.SemList(contents)
             }
             is TypedExpression.NamedFunctionBinding -> {
-                val functionRef = expression.functionRef
+                val functionRef = expression.resolvedFunctionRef
                 val bindings = expression.bindings.map { expr -> if (expr != null) evaluateExpression(expr, assignments, containingModule) else null }
                 return if (containingModule != null) {
-                    val resolved = containingModule.resolve(functionRef) ?: error("Invalid function reference: $functionRef")
-                    val module = getModule(resolved.entityRef.module, containingModule)
-                    return SemObject.FunctionBinding(FunctionBindingTarget.Named(functionRef.id), module, bindings)
+                    val module = getModule(functionRef.module, containingModule)
+                    return SemObject.FunctionBinding(FunctionBindingTarget.Named(functionRef), module, bindings)
                 } else {
                     // TODO: Use a resolver for natives so this can also handle constructors
                     EntityResolution(ResolvedEntityRef(CURRENT_NATIVE_MODULE_ID, functionRef.id), FunctionLikeType.NATIVE_FUNCTION)
-                    SemObject.FunctionBinding(FunctionBindingTarget.Named(functionRef.id), null, bindings)
+                    SemObject.FunctionBinding(FunctionBindingTarget.Named(functionRef), null, bindings)
                 }
             }
             is TypedExpression.ExpressionFunctionBinding -> {

--- a/kotlin/semlang-java-writer/src/main/kotlin/net/semlang/writejava/writeJava.kt
+++ b/kotlin/semlang-java-writer/src/main/kotlin/net/semlang/writejava/writeJava.kt
@@ -565,7 +565,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
                 unboundArgumentNames.add(argumentName)
 
                 val unparameterizedArgType = signature.argumentTypes[index]
-                val argType = unparameterizedArgType.replacingParameters(signature.typeParameters.zip(expression.chosenParameters).toMap())
+                val argType = unparameterizedArgType.replacingParameters(signature.typeParameters.map(Type::ParameterType).zip(expression.chosenParameters).toMap())
                 arguments.add(TypedExpression.Variable(argType, argumentName))
             } else {
                 arguments.add(binding)
@@ -759,7 +759,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
         }
 
         //TODO: Resolve beforehand, not after (part of multi-module support (?))
-        val interfaceRef = getInterfaceRefForAdapterRef(semlangType.ref)
+        val interfaceRef = getInterfaceRefForAdapterRef(semlangType.originalRef)
         if (interfaceRef != null) {
             val interfaceId = module.resolve(interfaceRef)?.entityRef?.id ?: error("error")
 //            val interfac = module.getInternalInterface(module.resolve(interfaceRef)?.entityRef ?: error("error"))
@@ -775,7 +775,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
             return ParameterizedTypeName.get(bareAdapterClass, interfaceJavaName, dataTypeParameter)
         }
 
-        val predefinedClassName: ClassName? = when (semlangType.ref.id.namespacedName) {
+        val predefinedClassName: ClassName? = when (semlangType.originalRef.id.namespacedName) {
             listOf("Sequence") -> ClassName.bestGuess("net.semlang.java.Sequence")
             listOf("Unicode", "String") -> ClassName.get(String::class.java)
             listOf("Unicode", "CodePoint") -> ClassName.get(Integer::class.java)
@@ -788,7 +788,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
         // associated package name for that"
 
         // TODO: Might end up being more complicated? This is probably not quite right
-        val className = predefinedClassName ?: ClassName.bestGuess(javaPackage.joinToString(".") + "." + semlangType.ref.toString())
+        val className = predefinedClassName ?: ClassName.bestGuess(javaPackage.joinToString(".") + "." + semlangType.originalRef.toString())
 
         if (semlangType.parameters.isEmpty()) {
             return className

--- a/kotlin/semlang-java-writer/src/main/kotlin/net/semlang/writejava/writeJava.kt
+++ b/kotlin/semlang-java-writer/src/main/kotlin/net/semlang/writejava/writeJava.kt
@@ -189,7 +189,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
 
         interfac.methods.zip(constructorArgs).forEach { (method, constructorArg) ->
 
-            val typeReplacements = interfac.typeParameters.map{s -> Type.NamedType.forParameter(s) as Type}.zip(interfaceParameters).toMap()
+            val typeReplacements = interfac.typeParameters.map{s -> Type.ParameterType(s) as Type}.zip(interfaceParameters).toMap()
             val methodBuilder = writeInterfaceMethod(method, false, typeReplacements)
             methodBuilder.addAnnotation(Override::class.java)
 
@@ -610,6 +610,10 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
     // This gets populated early on in the write() method.
     val namedFunctionCallStrategies = HashMap<EntityId, FunctionCallStrategy>()
 
+    private fun getNamedFunctionCallStrategy(functionRef: ResolvedEntityRef): FunctionCallStrategy {
+        // TODO: Currently we pretend other modules don't exist
+        return getNamedFunctionCallStrategy(functionRef.id)
+    }
     private fun getNamedFunctionCallStrategy(functionRef: EntityRef): FunctionCallStrategy {
         // TODO: Currently we pretend other modules don't exist
         return getNamedFunctionCallStrategy(functionRef.id)
@@ -718,6 +722,9 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
 
                 error("Literals not supported for type $resolvedType")
             }
+            is Type.ParameterType -> {
+                error("Literals not supported for parameter type $type")
+            }
         }
     }
 
@@ -734,6 +741,7 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
             is Type.Try -> ParameterizedTypeName.get(ClassName.get(java.util.Optional::class.java), getType(semlangType.parameter))
             is Type.FunctionType -> getFunctionType(semlangType)
             is Type.NamedType -> getNamedType(semlangType)
+            is Type.ParameterType -> TypeVariableName.get(semlangType.name)
         }
     }
 
@@ -745,7 +753,9 @@ private class JavaCodeWriter(val module: ValidatedModule, val javaPackage: List<
 
     private fun getNamedType(semlangType: Type.NamedType): TypeName {
         if (isInTypeParameterScope(semlangType)) {
-            return TypeVariableName.get(semlangType.ref.id.namespacedName.last())
+//            return TypeVariableName.get(semlangType.ref.id.namespacedName.last())
+            // TODO: Get rid of support for this
+            error("We should be able to get rid of this now")
         }
 
         //TODO: Resolve beforehand, not after (part of multi-module support (?))

--- a/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/LiteralValidation.kt
+++ b/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/LiteralValidation.kt
@@ -2,6 +2,7 @@ package net.semlang.parser
 
 import net.semlang.api.NativeStruct
 import net.semlang.api.Type
+import net.semlang.api.isNativeModule
 
 sealed class LiteralValidator {
     abstract fun validate(literal: String): Boolean
@@ -47,13 +48,13 @@ fun getTypeValidatorFor(type: Type): LiteralValidator? {
         Type.BOOLEAN -> LiteralValidator.BOOLEAN
         is Type.List -> null
         is Type.NamedType -> {
-            // TODO: Bug; support :lang:Unicode.String."Foo"
-            if (type.ref.moduleRef == null && type.ref.id == NativeStruct.UNICODE_STRING.id) {
+            if (isNativeModule(type.ref.module) && type.ref.id == NativeStruct.UNICODE_STRING.id) {
                 return LiteralValidator.UNICODE_STRING
             }
             null
         }
         is Type.FunctionType -> null
         is Type.Try -> null
+        is Type.ParameterType -> null
     }
 }

--- a/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/jsonWriter.kt
+++ b/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/jsonWriter.kt
@@ -158,7 +158,7 @@ private fun toTypeNode(type: Type): JsonNode {
         }
         is Type.NamedType -> {
             val node = ObjectNode(factory)
-            node.put("name", type.ref.toString())
+            node.put("name", type.originalRef.toString())
             if (type.parameters.isNotEmpty()) {
                 val paramsArray = node.putArray("params")
                 type.parameters.forEach { parameter ->

--- a/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/validator.kt
+++ b/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/validator.kt
@@ -671,7 +671,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
                 postBindingArgumentTypes,
                 signature.outputType.replacingParameters(parameterMap))
 
-        return TypedExpression.NamedFunctionBinding(postBindingType, functionRef, bindings, chosenParameters)
+        return TypedExpression.NamedFunctionBinding(postBindingType, functionRef, resolvedRef.entityRef, bindings, chosenParameters)
     }
 
     private fun validateFollowExpression(expression: Expression.Follow, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
@@ -777,7 +777,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             errors.add(Issue("The function $functionRef expects argument types ${groundSignature.argumentTypes}, but is given arguments with types $argumentTypes", expression.location, IssueLevel.ERROR))
         }
 
-        return TypedExpression.NamedFunctionCall(groundSignature.outputType, functionRef, arguments, expression.chosenParameters)
+        return TypedExpression.NamedFunctionCall(groundSignature.outputType, functionRef, functionResolvedRef.entityRef, arguments, expression.chosenParameters)
     }
 
     private fun ground(signature: TypeSignature, chosenTypes: List<Type>, functionId: EntityId, location: Location?): GroundedTypeSignature? {

--- a/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/validator.kt
+++ b/kotlin/semlang-parser/src/main/kotlin/net/semlang/parser/validator.kt
@@ -2,6 +2,7 @@ package net.semlang.parser
 
 import net.semlang.api.*
 import net.semlang.api.Function
+import net.semlang.transforms.invalidate
 import java.io.File
 import java.util.*
 
@@ -310,7 +311,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         val upstreamFunctions = HashMap<ResolvedEntityRef, FunctionInfo>()
 
         // (We don't need the idPosition for functions in upstream modules)
-        val functionInfo = fun(signature: TypeSignature): FunctionInfo { return FunctionInfo(signature, null) }
+        val functionInfo = fun(signature: TypeSignature): FunctionInfo { return FunctionInfo(invalidate(signature), null) }
 
         // TODO: Fix this to use nativeModuleVersion
         val nativeModuleId = CURRENT_NATIVE_MODULE_ID
@@ -364,72 +365,110 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
     private fun validateFunction(function: Function, typeInfo: AllTypeInfo): ValidatedFunction? {
         //TODO: Validate that no two arguments have the same name
 
-        val arguments = validateArguments(function.arguments, typeInfo, function.typeParameters.toSet())
-
+        val arguments = validateArguments(function.arguments, typeInfo, function.typeParameters.toSet()) ?: return null
+        val returnType = validateType(function.returnType, typeInfo, function.typeParameters.toSet()) ?: return null
 
         //TODO: Validate that type parameters don't share a name with something important
         val variableTypes = getArgumentVariableTypes(arguments)
         val block = validateBlock(function.block, variableTypes, typeInfo, function.typeParameters.toSet(), function.id) ?: return null
-        if (function.returnType != block.type) {
+        if (returnType != block.type) {
             errors.add(Issue("Stated return type ${function.returnType} does not match the block's actual return type ${block.type}", function.returnTypeLocation, IssueLevel.ERROR))
         }
 
-        return ValidatedFunction(function.id, function.typeParameters, arguments, function.returnType, block, function.annotations)
+        return ValidatedFunction(function.id, function.typeParameters, arguments, returnType, block, function.annotations)
     }
 
-    private fun validateArguments(arguments: List<UnvalidatedArgument>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): List<Argument> {
-        val validatedArguments = ArrayList<Argument>()
-        arguments.forEach { argument ->
-            val type = argument.type
-            if (typeNotRecognized(type, typeInfo, typeParametersInScope)) {
-                errors.add(Issue("Unrecognized type $type", argument.location, IssueLevel.ERROR))
-            }
-            validatedArguments.add(Argument(argument.name, argument.type))
-        }
-        return validatedArguments
-    }
-
-    private fun typeNotRecognized(type: Type, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
-        return !typeRecognized(type, typeInfo, typeParametersInScope)
-    }
-
-    private fun typeRecognized(type: Type, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
+    private fun validateType(type: UnvalidatedType, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Type? {
         return when (type) {
-            Type.INTEGER -> true
-            Type.NATURAL -> true
-            Type.BOOLEAN -> true
-            is Type.List -> typeRecognized(type.parameter, typeInfo, typeParametersInScope)
-            is Type.Try -> typeRecognized(type.parameter, typeInfo, typeParametersInScope)
-            is Type.FunctionType -> {
-                typeRecognized(type.outputType, typeInfo, typeParametersInScope) && type.argTypes.all { typeRecognized(it, typeInfo, typeParametersInScope) }
+            UnvalidatedType.INTEGER -> Type.INTEGER
+            UnvalidatedType.NATURAL -> Type.NATURAL
+            UnvalidatedType.BOOLEAN -> Type.BOOLEAN
+            is UnvalidatedType.List -> {
+                val parameter = validateType(type.parameter, typeInfo, typeParametersInScope) ?: return null
+                Type.List(parameter)
             }
-            is Type.NamedType -> {
-                val typeNameRecognized = typeNameRecognized(type.ref, typeInfo, typeParametersInScope)
-                val resolution = typeInfo.resolver.resolve(type.ref)
-                if (!typeNameRecognized) {
-                    false
+            is UnvalidatedType.Try -> {
+                val parameter = validateType(type.parameter, typeInfo, typeParametersInScope) ?: return null
+                Type.Try(parameter)
+            }
+            is UnvalidatedType.FunctionType -> {
+                val argTypes = type.argTypes.map { argType -> validateType(argType, typeInfo, typeParametersInScope) ?: return null }
+                val outputType = validateType(type.outputType, typeInfo, typeParametersInScope) ?: return null
+                Type.FunctionType(argTypes, outputType)
+            }
+            is UnvalidatedType.NamedType -> {
+                if (type.parameters.isEmpty()
+                        && type.ref.moduleRef == null
+                        && type.ref.id.namespacedName.size == 1
+                        && typeParametersInScope.contains(type.ref.id.namespacedName[0])) {
+                    Type.ParameterType(type.ref.id.namespacedName[0])
                 } else {
-                    type.parameters.all { typeRecognized(it, typeInfo, typeParametersInScope) }
+                    val resolved = typeInfo.resolver.resolve(type.ref)
+                    if (resolved == null) {
+                        // TODO: Give this a location (which probably requires putting locations on UnvalidatedTypes; try to make locations sane first)
+                        errors.add(Issue("Unresolved type reference: ${type.ref}", null, IssueLevel.ERROR))
+                        return null
+                    }
+                    val parameters = type.parameters.map { parameter -> validateType(parameter, typeInfo, typeParametersInScope) ?: return null }
+                    Type.NamedType(resolved.entityRef, type.ref, parameters)
                 }
             }
         }
     }
 
-    private fun typeNameRecognized(ref: EntityRef, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
-        val resolution = typeInfo.resolver.resolve(ref)
-        if (resolution != null) {
-            return true
+    private fun validateArguments(arguments: List<UnvalidatedArgument>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): List<Argument>? {
+        val validatedArguments = ArrayList<Argument>()
+        for (argument in arguments) {
+            val type = validateType(argument.type, typeInfo, typeParametersInScope) ?: return null
+//            if (typeNotRecognized(type, typeInfo, typeParametersInScope)) {
+//                errors.add(Issue("Unrecognized type $type", argument.location, IssueLevel.ERROR))
+//            }
+            validatedArguments.add(Argument(argument.name, type))
         }
-        // Check the type parameters
-        if (ref.moduleRef == null) {
-            val namespacedName = ref.id.namespacedName
-            val onlyOne = namespacedName.singleOrNull()
-            if (onlyOne != null) {
-                return typeParametersInScope.contains(onlyOne)
-            }
-        }
-        return false
+        return validatedArguments
     }
+
+//    private fun typeNotRecognized(type: Type, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
+//        return !typeRecognized(type, typeInfo, typeParametersInScope)
+//    }
+//
+//    private fun typeRecognized(type: Type, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
+//        return when (type) {
+//            Type.INTEGER -> true
+//            Type.NATURAL -> true
+//            Type.BOOLEAN -> true
+//            is Type.List -> typeRecognized(type.parameter, typeInfo, typeParametersInScope)
+//            is Type.Try -> typeRecognized(type.parameter, typeInfo, typeParametersInScope)
+//            is Type.FunctionType -> {
+//                typeRecognized(type.outputType, typeInfo, typeParametersInScope) && type.argTypes.all { typeRecognized(it, typeInfo, typeParametersInScope) }
+//            }
+//            is Type.NamedType -> {
+//                val typeNameRecognized = typeNameRecognized(type.ref, typeInfo, typeParametersInScope)
+//                val resolution = typeInfo.resolver.resolve(type.ref)
+//                if (!typeNameRecognized) {
+//                    false
+//                } else {
+//                    type.parameters.all { typeRecognized(it, typeInfo, typeParametersInScope) }
+//                }
+//            }
+//        }
+//    }
+
+//    private fun typeNameRecognized(ref: EntityRef, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Boolean {
+//        val resolution = typeInfo.resolver.resolve(ref)
+//        if (resolution != null) {
+//            return true
+//        }
+//        // Check the type parameters
+//        if (ref.moduleRef == null) {
+//            val namespacedName = ref.id.namespacedName
+//            val onlyOne = namespacedName.singleOrNull()
+//            if (onlyOne != null) {
+//                return typeParametersInScope.contains(onlyOne)
+//            }
+//        }
+//        return false
+//    }
 
     private fun getArgumentVariableTypes(arguments: List<Argument>): Map<String, Type> {
         return arguments.associate { argument -> Pair(argument.name, argument.type) }
@@ -438,29 +477,50 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
 
     private sealed class TypeInfo {
         abstract val idLocation: Location?
-        data class Struct(val typeParameters: List<String>, val members: Map<String, Member>, val usesRequires: Boolean, override val idLocation: Location?): TypeInfo()
-        data class Interface(val typeParameters: List<String>, val methodTypes: Map<String, Type.FunctionType>, override val idLocation: Location?): TypeInfo()
+        data class Struct(val typeParameters: List<String>, val memberTypes: Map<String, UnvalidatedType>, val usesRequires: Boolean, override val idLocation: Location?): TypeInfo()
+        data class Interface(val typeParameters: List<String>, val methodTypes: Map<String, UnvalidatedType.FunctionType>, override val idLocation: Location?): TypeInfo()
     }
-    private data class FunctionInfo(val signature: TypeSignature, val idLocation: Location?)
+    private data class FunctionInfo(val signature: UnvalidatedTypeSignature, val idLocation: Location?)
 
     private fun getTypeInfo(struct: UnvalidatedStruct): TypeInfo.Struct {
-        return TypeInfo.Struct(struct.typeParameters, struct.members.associateBy(Member::name), struct.requires != null, struct.idLocation)
+        return TypeInfo.Struct(struct.typeParameters, getUnvalidatedMemberTypeMap(struct.members), struct.requires != null, struct.idLocation)
     }
-    // TODO: Null position
     private fun getTypeInfo(struct: Struct, idLocation: Location?): TypeInfo.Struct {
-        return TypeInfo.Struct(struct.typeParameters, struct.members.associateBy(Member::name), struct.requires != null, idLocation)
+        return TypeInfo.Struct(struct.typeParameters, getMemberTypeMap(struct.members), struct.requires != null, idLocation)
     }
 
     private fun getTypeInfo(interfac: UnvalidatedInterface): TypeInfo.Interface {
-        return TypeInfo.Interface(interfac.typeParameters, getTypeMap(interfac.methods), interfac.idLocation)
+        return TypeInfo.Interface(interfac.typeParameters, getUnvalidatedMethodTypeMap(interfac.methods), interfac.idLocation)
     }
-    // TODO: Null position
     private fun getTypeInfo(interfac: Interface, idLocation: Location?): TypeInfo.Interface {
-        return TypeInfo.Interface(interfac.typeParameters, getTypeMapPostValidation(interfac.methods), idLocation)
+        return TypeInfo.Interface(interfac.typeParameters, getMethodTypeMap(interfac.methods), idLocation)
     }
 
-    private fun getTypeMap(methods: List<UnvalidatedMethod>): Map<String, Type.FunctionType> {
-        val typeMap = HashMap<String, Type.FunctionType>()
+    private fun getUnvalidatedMemberTypeMap(members: List<UnvalidatedMember>): Map<String, UnvalidatedType> {
+        val typeMap = HashMap<String, UnvalidatedType>()
+        for (member in members) {
+            if (typeMap.containsKey(member.name)) {
+                // TODO: Fix this...
+//                error("Duplicate member name ${member.name}")
+            } else {
+                typeMap.put(member.name, member.type)
+            }
+        }
+        return typeMap
+    }
+    private fun getMemberTypeMap(members: List<Member>): Map<String, UnvalidatedType> {
+        val typeMap = HashMap<String, UnvalidatedType>()
+        for (member in members) {
+            if (typeMap.containsKey(member.name)) {
+                error("Duplicate member name ${member.name}")
+            } else {
+                typeMap.put(member.name, invalidate(member.type))
+            }
+        }
+        return typeMap
+    }
+    private fun getUnvalidatedMethodTypeMap(methods: List<UnvalidatedMethod>): Map<String, UnvalidatedType.FunctionType> {
+        val typeMap = HashMap<String, UnvalidatedType.FunctionType>()
         for (method in methods) {
             if (typeMap.containsKey(method.name)) {
                 error("Duplicate method name ${method.name}")
@@ -470,13 +530,13 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         }
         return typeMap
     }
-    private fun getTypeMapPostValidation(methods: List<Method>): Map<String, Type.FunctionType> {
-        val typeMap = HashMap<String, Type.FunctionType>()
+    private fun getMethodTypeMap(methods: List<Method>): Map<String, UnvalidatedType.FunctionType> {
+        val typeMap = HashMap<String, UnvalidatedType.FunctionType>()
         for (method in methods) {
             if (typeMap.containsKey(method.name)) {
                 error("Duplicate method name ${method.name}")
             } else {
-                typeMap.put(method.name, method.functionType)
+                typeMap.put(method.name, invalidate(method.functionType) as UnvalidatedType.FunctionType)
             }
         }
         return typeMap
@@ -523,9 +583,13 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             }
 
             val validatedExpression = validateExpression(assignment.expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId) ?: return null
-            if (assignment.type != null && (validatedExpression.type != assignment.type)) {
-                fail("In function $containingFunctionId, the variable ${assignment.name} is supposed to be of type ${assignment.type}, " +
-                        "but the expression given has actual type ${validatedExpression.type}")
+            val unvalidatedAssignmentType = assignment.type
+            if (unvalidatedAssignmentType != null) {
+                val assignmentType = validateType(unvalidatedAssignmentType, typeInfo, typeParametersInScope)
+                if (validatedExpression.type != assignmentType) {
+                    fail("In function $containingFunctionId, the variable ${assignment.name} is supposed to be of type ${assignment.type}, " +
+                            "but the expression given has actual type ${validatedExpression.type}")
+                }
             }
 
             validatedAssignments.add(ValidatedAssignment(assignment.name, validatedExpression.type, validatedExpression))
@@ -552,7 +616,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             is Expression.Follow -> validateFollowExpression(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
             is Expression.NamedFunctionCall -> validateNamedFunctionCallExpression(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
             is Expression.ExpressionFunctionCall -> validateExpressionFunctionCallExpression(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
-            is Expression.Literal -> validateLiteralExpression(expression, typeInfo)
+            is Expression.Literal -> validateLiteralExpression(expression, typeInfo, typeParametersInScope)
             is Expression.ListLiteral -> validateListLiteralExpression(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
             is Expression.NamedFunctionBinding -> validateNamedFunctionBinding(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
             is Expression.ExpressionFunctionBinding -> validateExpressionFunctionBinding(expression, variableTypes, typeInfo, typeParametersInScope, containingFunctionId)
@@ -566,7 +630,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
                 errors.add(Issue("Argument name ${arg.name} shadows an existing variable name", arg.location, IssueLevel.ERROR))
             }
         }
-        val validatedArguments = validateArguments(expression.arguments, typeInfo, typeParametersInScope)
+        val validatedArguments = validateArguments(expression.arguments, typeInfo, typeParametersInScope) ?: return null
 
         val incomingVariableTypes: Map<String, Type> = variableTypes + validatedArguments.asVariableTypesMap()
         val validatedBlock = validateBlock(expression.block, incomingVariableTypes, typeInfo, typeParametersInScope, containingFunctionId) ?: return null
@@ -620,8 +684,9 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         val postBindingType = Type.FunctionType(
                 postBindingArgumentTypes,
                 functionType.outputType)
+        val chosenParameters = expression.chosenParameters.map { chosenParameter -> validateType(chosenParameter, typeInfo, typeParametersInScope) ?: return null }
 
-        return TypedExpression.ExpressionFunctionBinding(postBindingType, functionExpression, bindings, expression.chosenParameters)
+        return TypedExpression.ExpressionFunctionBinding(postBindingType, functionExpression, bindings, chosenParameters)
     }
 
     private fun validateNamedFunctionBinding(expression: Expression.NamedFunctionBinding, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
@@ -633,17 +698,19 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             fail("In function $containingFunctionId, resolved a function with ID $functionRef but could not find the signature")
         }
         val signature = functionInfo.signature
-        val chosenParameters = expression.chosenParameters
+        val chosenParameters = expression.chosenParameters.map { chosenParameter -> validateType(chosenParameter, typeInfo, typeParametersInScope) ?: return null }
         if (chosenParameters.size != signature.typeParameters.size) {
             fail("In function $containingFunctionId, referenced a function $functionRef with type parameters ${signature.typeParameters}, but used an incorrect number of type parameters, passing in $chosenParameters")
         }
-        val typeParameters = signature.typeParameters
+//        val typeParameters = signature.typeParameters
 
-        val parameterMap = makeParameterMap(typeParameters, chosenParameters, resolvedRef.entityRef.id, expression.location) ?: return null
-        val preBindingArgumentTypes = signature.argumentTypes.map { type -> type.replacingParameters(parameterMap) }
+        val expectedFunctionType = parameterizeAndValidateSignature(signature, chosenParameters, typeInfo, typeParametersInScope) ?: return null
 
-        if (preBindingArgumentTypes.size != expression.bindings.size) {
-            errors.add(Issue("Tried to bind function $functionRef with ${expression.bindings.size} bindings, but it takes ${preBindingArgumentTypes.size} arguments", expression.location, IssueLevel.ERROR))
+//        val parameterMap = makeParameterMap(typeParameters, chosenParameters, resolvedRef.entityRef.id, expression.location) ?: return null
+//        val preBindingArgumentTypes = signature.argumentTypes.map { type -> type.replacingParameters(parameterMap) }
+
+        if (expectedFunctionType.argTypes.size != expression.bindings.size) {
+            errors.add(Issue("Tried to bind function $functionRef with ${expression.bindings.size} bindings, but it takes ${expectedFunctionType.argTypes.size} arguments", expression.location, IssueLevel.ERROR))
             return null
         }
 
@@ -656,7 +723,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         }
 
         val postBindingArgumentTypes = ArrayList<Type>()
-        for (entry in preBindingArgumentTypes.zip(bindings)) {
+        for (entry in expectedFunctionType.argTypes.zip(bindings)) {
             val type = entry.first
             val binding = entry.second
             if (binding == null) {
@@ -669,7 +736,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         }
         val postBindingType = Type.FunctionType(
                 postBindingArgumentTypes,
-                signature.outputType.replacingParameters(parameterMap))
+                expectedFunctionType.outputType)
 
         return TypedExpression.NamedFunctionBinding(postBindingType, functionRef, resolvedRef.entityRef, bindings, chosenParameters)
     }
@@ -683,7 +750,7 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             return null
         }
 
-        val resolvedParentType = typeInfo.resolver.resolve(parentNamedType.ref)
+        val resolvedParentType = typeInfo.resolver.resolve(parentNamedType.originalRef)
         if (resolvedParentType == null) {
             errors.add(Issue("Cannot dereference an expression $structureExpression of unrecognized type ${structureExpression.type}", expression.location, IssueLevel.ERROR))
             return null
@@ -692,17 +759,18 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
 
         return when (parentTypeInfo) {
             is TypeInfo.Struct -> {
-                val member = parentTypeInfo.members[expression.name]
-                if (member == null) {
+                val memberType = parentTypeInfo.memberTypes[expression.name]
+                if (memberType == null) {
                     errors.add(Issue("Struct type $parentNamedType does not have a member named '${expression.name}'", expression.location, IssueLevel.ERROR))
                     return null
                 }
 
                 // Type parameters come from the struct definition itself
                 // Chosen types come from the struct type known for the variable
-                val typeParameters = parentTypeInfo.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
+                val typeParameters = parentTypeInfo.typeParameters
                 val chosenTypes = parentNamedType.getParameterizedTypes()
-                val type = parameterizeType(member.type, typeParameters, chosenTypes, resolvedParentType.entityRef.id, expression.location) ?: return null
+//                val type = parameterizeType(memberType.type, typeParameters, chosenTypes, resolvedParentType.entityRef.id, expression.location) ?: return null
+                val type = parameterizeAndValidateType(memberType, typeParameters.map(Type::ParameterType), chosenTypes, typeInfo, typeParametersInScope) ?: return null
                 //TODO: Ground this if needed
 
                 return TypedExpression.Follow(type, structureExpression, expression.name)
@@ -717,13 +785,25 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
                     return null
                 }
 
-                val typeParameters = interfac.typeParameters.map { paramName -> Type.NamedType.forParameter(paramName) }
+                val typeParameters = interfac.typeParameters
                 val chosenTypes = interfaceType.getParameterizedTypes()
-                val type = parameterizeType(methodType, typeParameters, chosenTypes, resolvedParentType.entityRef.id, expression.location) ?: return null
+//                val type = parameterizeType(methodType, typeParameters, chosenTypes, resolvedParentType.entityRef.id, expression.location) ?: return null
+                val type = parameterizeAndValidateType(methodType, typeParameters.map(Type::ParameterType), chosenTypes, typeInfo, typeParametersInScope) ?: return null
 
                 return TypedExpression.Follow(type, structureExpression, expression.name)
             }
         }
+    }
+
+    private fun parameterizeAndValidateType(unvalidatedType: UnvalidatedType, typeParameters: List<Type.ParameterType>, chosenTypes: List<Type>, typeInfo: Validator.AllTypeInfo, typeParametersInScope: Set<String>): Type? {
+        val type = validateType(unvalidatedType, typeInfo, typeParametersInScope + typeParameters.map(Type.ParameterType::name)) ?: return null
+
+        if (typeParameters.size != chosenTypes.size) {
+            error("Give me a better error message")
+        }
+        val parameterMap = typeParameters.zip(chosenTypes).toMap()
+
+        return type.replacingParameters(parameterMap)
     }
 
     private fun validateExpressionFunctionCallExpression(expression: Expression.ExpressionFunctionCall, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
@@ -746,8 +826,9 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             errors.add(Issue("The bound function $functionExpression expects argument types ${functionType.argTypes}, but we give it types $argumentTypes", expression.location, IssueLevel.ERROR))
             return null
         }
+        val chosenParameters = expression.chosenParameters.map { chosenParameter -> validateType(chosenParameter, typeInfo, typeParametersInScope) ?: return null }
 
-        return TypedExpression.ExpressionFunctionCall(functionType.outputType, functionExpression, arguments, expression.chosenParameters)
+        return TypedExpression.ExpressionFunctionCall(functionType.outputType, functionExpression, arguments, chosenParameters)
     }
 
     private fun validateNamedFunctionCallExpression(expression: Expression.NamedFunctionCall, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
@@ -772,19 +853,34 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         //TODO: Maybe compare argument size before grounding?
 
         //Ground the signature
-        val groundSignature = ground(signature, expression.chosenParameters, functionRef.id, expression.functionRefLocation) ?: return null
-        if (argumentTypes != groundSignature.argumentTypes) {
-            errors.add(Issue("The function $functionRef expects argument types ${groundSignature.argumentTypes}, but is given arguments with types $argumentTypes", expression.location, IssueLevel.ERROR))
+        val chosenParameters = expression.chosenParameters.map { chosenParameter -> validateType(chosenParameter, typeInfo, typeParametersInScope) ?: return null }
+//        val groundSignature = ground(signature, chosenParameters, functionRef.id, expression.functionRefLocation) ?: return null
+        if (signature.typeParameters.size != chosenParameters.size) {
+            errors.add(Issue("Expected ${signature.typeParameters.size} type parameters, but got ${chosenParameters.size}", expression.functionRefLocation, IssueLevel.ERROR))
+            return null
+        }
+        val functionType = parameterizeAndValidateSignature(signature, chosenParameters, typeInfo, typeParametersInScope) ?: return null
+        if (argumentTypes != functionType.argTypes) {
+            errors.add(Issue("The function $functionRef expects argument types ${functionType.argTypes}, but is given arguments with types $argumentTypes", expression.location, IssueLevel.ERROR))
         }
 
-        return TypedExpression.NamedFunctionCall(groundSignature.outputType, functionRef, functionResolvedRef.entityRef, arguments, expression.chosenParameters)
+        return TypedExpression.NamedFunctionCall(functionType.outputType, functionRef, functionResolvedRef.entityRef, arguments, chosenParameters)
     }
 
-    private fun ground(signature: TypeSignature, chosenTypes: List<Type>, functionId: EntityId, location: Location?): GroundedTypeSignature? {
-        val groundedArgumentTypes = signature.argumentTypes.map { t -> parameterizeType(t, signature.typeParameters, chosenTypes, functionId, location) ?: return null }
-        val groundedOutputType = parameterizeType(signature.outputType, signature.typeParameters, chosenTypes, functionId, location) ?: return null
-        return GroundedTypeSignature(signature.id, groundedArgumentTypes, groundedOutputType)
+    private fun parameterizeAndValidateSignature(signature: UnvalidatedTypeSignature, chosenParameters: List<Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): Type.FunctionType? {
+        val typeParameters = signature.typeParameters.map(Type::ParameterType)
+        try {
+            return parameterizeAndValidateType(signature.getFunctionType(), typeParameters, chosenParameters, typeInfo, typeParametersInScope) as Type.FunctionType?
+        } catch (e: RuntimeException) {
+            throw RuntimeException("Signature being parameterized is $signature", e)
+        }
     }
+
+//    private fun ground(signature: TypeSignature, chosenTypes: List<Type>, functionId: EntityId, location: Location?): Type.FunctionType? {
+//        val groundedArgumentTypes = signature.argumentTypes.map { t -> parameterizeType(t, signature.typeParameters, chosenTypes, functionId, location) ?: return null }
+//        val groundedOutputType = parameterizeType(signature.outputType, signature.typeParameters, chosenTypes, functionId, location) ?: return null
+//        return GroundedTypeSignature(signature.id, groundedArgumentTypes, groundedOutputType)
+//    }
 
     // TODO: We're disagreeing in multiple places on List<Type> vs. List<String>, should fix that at some point
     private fun makeParameterMap(parameters: List<Type>, chosenTypes: List<Type>, functionId: EntityId, location: Location?): Map<Type, Type>? {
@@ -812,8 +908,8 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
         return typeWithWrongParameters.replacingParameters(parameterMap)
     }
 
-    private fun validateLiteralExpression(expression: Expression.Literal, typeInfo: AllTypeInfo): TypedExpression {
-        val typeChain = getLiteralTypeChain(expression.type, expression.location, typeInfo)
+    private fun validateLiteralExpression(expression: Expression.Literal, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): TypedExpression? {
+        val typeChain = getLiteralTypeChain(expression.type, expression.location, typeInfo, typeParametersInScope)
 
         if (typeChain != null) {
             val nativeLiteralType = typeChain[0]
@@ -823,11 +919,12 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             if (!isValid) {
                 errors.add(Issue("Invalid literal value '${expression.literal}' for type '${expression.type}'", expression.location, IssueLevel.ERROR))
             }
+            // TODO: Someday we need to check for literal values that violate "requires" blocks at validation time
+            return TypedExpression.Literal(typeChain.last(), expression.literal)
         } else if (errors.isEmpty()) {
             fail("Something went wrong")
         }
-        // TODO: Someday we need to check for invalid literal values at validation time
-        return TypedExpression.Literal(expression.type, expression.literal)
+        return null
     }
 
     /**
@@ -842,22 +939,23 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
      * native literal implementation) and then following the chain in successive layers
      * outwards to the original type.
      */
-    private fun getLiteralTypeChain(initialType: Type, literalLocation: Location?, typeInfo: AllTypeInfo): List<Type>? {
-        var type = initialType
+    private fun getLiteralTypeChain(initialType: UnvalidatedType, literalLocation: Location?, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): List<Type>? {
+        var type = validateType(initialType, typeInfo, typeParametersInScope) ?: return null
         val list = ArrayList<Type>()
         list.add(type)
         while (getTypeValidatorFor(type) == null) {
             if (type is Type.NamedType) {
-                val resolvedType = typeInfo.resolver.resolve(type.ref) ?: fail("Could not resolve type ${type.ref}")
+                val resolvedType = typeInfo.resolver.resolve(type.originalRef) ?: fail("Could not resolve type ${type.ref}")
                 val struct = typeInfo.getTypeInfo(resolvedType.entityRef) as? TypeInfo.Struct ?: fail("Trying to get a literal of a non-struct named type $resolvedType")
 
                 if (struct.typeParameters.isNotEmpty()) {
                     fail("Can't have a literal of a type with type parameters: $type")
                 }
-                if (struct.members.size != 1) {
+                if (struct.memberTypes.size != 1) {
                     fail("Can't have a literal of a struct type with more than one member")
                 }
-                val memberType = struct.members.values.single().type
+                val unvalidatedMemberType = struct.memberTypes.values.single()
+                val memberType = validateType(unvalidatedMemberType, typeInfo, struct.typeParameters.toSet()) ?: return null
                 if (list.contains(memberType)) {
                     errors.add(Issue("Error: Literal type involves cycle of structs: ${list}", literalLocation, IssueLevel.ERROR))
                     return null
@@ -874,18 +972,19 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
     }
 
     private fun validateListLiteralExpression(expression: Expression.ListLiteral, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
-        val listType = Type.List(expression.chosenParameter)
+        val chosenParameter = validateType(expression.chosenParameter, typeInfo, typeParametersInScope) ?: return null
+        val listType = Type.List(chosenParameter)
 
         val contents = expression.contents.map { item ->
             validateExpression(item, variableTypes, typeInfo, typeParametersInScope, containingFunctionId) ?: return null
         }
         contents.forEach { item ->
-            if (item.type != expression.chosenParameter) {
+            if (item.type != chosenParameter) {
                 error("Put an expression $item of type ${item.type} in a list literal of type ${listType}")
             }
         }
 
-        return TypedExpression.ListLiteral(listType, contents, expression.chosenParameter)
+        return TypedExpression.ListLiteral(listType, contents, chosenParameter)
     }
 
     private fun validateIfThenExpression(expression: Expression.IfThen, variableTypes: Map<String, Type>, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>, containingFunctionId: EntityId): TypedExpression? {
@@ -938,8 +1037,9 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
     }
 
     private fun validateStruct(struct: UnvalidatedStruct, typeInfo: AllTypeInfo): Struct? {
-        validateMemberNames(struct)
-        val memberTypes = struct.members.associate { member -> member.name to member.type }
+        val members = validateMembers(struct, typeInfo, struct.typeParameters.toSet()) ?: return null
+
+        val memberTypes = members.associate { member -> member.name to member.type }
 
         val fakeContainingFunctionId = EntityId(struct.id.namespacedName + "requires")
         val uncheckedRequires = struct.requires
@@ -955,10 +1055,13 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             errors.add(issue)
         }
 
-        return Struct(struct.id, struct.typeParameters, struct.members, requires, struct.annotations)
+        return Struct(struct.id, moduleId, struct.typeParameters, members, requires, struct.annotations)
     }
 
-    private fun validateMemberNames(struct: UnvalidatedStruct) {
+
+
+    private fun validateMembers(struct: UnvalidatedStruct, typeInfo: AllTypeInfo, typeParametersInScope: Set<String>): List<Member>? {
+        // Check for name duplication
         val allNames = HashSet<String>()
         for (member in struct.members) {
             if (allNames.contains(member.name)) {
@@ -967,28 +1070,37 @@ private class Validator(val moduleId: ModuleId, val nativeModuleVersion: String,
             }
             allNames.add(member.name)
         }
+
+        return struct.members.map { member ->
+            val type = validateType(member.type, typeInfo, typeParametersInScope) ?: return null
+            Member(member.name, type)
+        }
     }
 
     private fun validateInterfaces(interfaces: List<UnvalidatedInterface>, typeInfo: AllTypeInfo): Map<EntityId, Interface> {
         val validatedInterfaces = HashMap<EntityId, Interface>()
         for (interfac in interfaces) {
-            validatedInterfaces.put(interfac.id, validateInterface(interfac, typeInfo))
+            val validatedInterface = validateInterface(interfac, typeInfo)
+            if (validatedInterface != null) {
+                validatedInterfaces.put(interfac.id, validatedInterface)
+            }
         }
         return validatedInterfaces
     }
 
-    private fun validateInterface(interfac: UnvalidatedInterface, typeInfo: AllTypeInfo): Interface {
+    private fun validateInterface(interfac: UnvalidatedInterface, typeInfo: AllTypeInfo): Interface? {
         // TODO: Do some actual validation of interfaces
-        val methods = validateMethods(interfac.methods, typeInfo, interfac.typeParameters.toSet())
-        return Interface(interfac.id, interfac.typeParameters, methods, interfac.annotations)
+        val methods = validateMethods(interfac.methods, typeInfo, interfac.typeParameters.toSet()) ?: return null
+        return Interface(interfac.id, moduleId, interfac.typeParameters, methods, interfac.annotations)
     }
 
-    private fun validateMethods(methods: List<UnvalidatedMethod>, typeInfo: AllTypeInfo, interfaceTypeParameters: Set<String>): List<Method> {
+    private fun validateMethods(methods: List<UnvalidatedMethod>, typeInfo: AllTypeInfo, interfaceTypeParameters: Set<String>): List<Method>? {
         // TODO: Do some actual validation of methods
         return methods.map { method ->
             val typeParametersVisibleToMethod = interfaceTypeParameters + method.typeParameters.toSet()
-            val arguments = validateArguments(method.arguments, typeInfo, typeParametersVisibleToMethod)
-            Method(method.name, method.typeParameters, arguments, method.returnType)
+            val arguments = validateArguments(method.arguments, typeInfo, typeParametersVisibleToMethod) ?: return null
+            val returnType = validateType(method.returnType, typeInfo, typeParametersVisibleToMethod) ?: return null
+            Method(method.name, method.typeParameters, arguments, returnType)
         }
     }
 }

--- a/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/fromSem0.kt
+++ b/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/fromSem0.kt
@@ -36,9 +36,9 @@ private class Sem0To1Converter(val input: S0Context) {
         return UnvalidatedStruct(id, struct.typeParameters, members, requires, annotations, null)
     }
 
-    private fun apply(member: S0Member): Member {
+    private fun apply(member: S0Member): UnvalidatedMember {
         val type = apply(member.type)
-        return Member(member.name, type)
+        return UnvalidatedMember(member.name, type)
     }
 
     private fun apply(annotation: S0Annotation): Annotation {
@@ -122,26 +122,26 @@ private class Sem0To1Converter(val input: S0Context) {
         return Assignment(assignment.name, null, expression, null)
     }
 
-    private fun apply(type: S0Type): Type {
+    private fun apply(type: S0Type): UnvalidatedType {
         return when (type) {
-            S0Type.Integer -> Type.INTEGER
-            S0Type.Natural -> Type.NATURAL
-            S0Type.Boolean -> Type.BOOLEAN
+            S0Type.Integer -> UnvalidatedType.INTEGER
+            S0Type.Natural -> UnvalidatedType.NATURAL
+            S0Type.Boolean -> UnvalidatedType.BOOLEAN
             is S0Type.List -> {
-                Type.List(apply(type.parameter))
+                UnvalidatedType.List(apply(type.parameter))
             }
             is S0Type.Try -> {
-                Type.Try(apply(type.parameter))
+                UnvalidatedType.Try(apply(type.parameter))
             }
             is S0Type.FunctionType -> {
                 val argTypes = type.argTypes.map(this::apply)
                 val outputType = apply(type.outputType)
-                Type.FunctionType(argTypes, outputType)
+                UnvalidatedType.FunctionType(argTypes, outputType)
             }
             is S0Type.NamedType -> {
                 val ref = convertRef(type.id)
                 val parameters = type.parameters.map(this::apply)
-                Type.NamedType(ref, parameters)
+                UnvalidatedType.NamedType(ref, parameters)
             }
         }
     }

--- a/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/interfacesToStructs.kt
+++ b/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/interfacesToStructs.kt
@@ -86,18 +86,18 @@ private class InterfaceToStructConverter(private val context: RawContext) {
 
     private fun generateAdaptFunction(interfac: UnvalidatedInterface) {
         val adaptFunctionId = EntityId(interfac.id.namespacedName + "adapt")
-        val dataParameterType = Type.NamedType.forParameter(interfac.getAdapterStruct().typeParameters[0])
-        val adapterType = Type.NamedType(interfac.adapterId.asRef(), interfac.getAdapterStruct().typeParameters.map { param -> Type.NamedType.forParameter(param) })
+        val dataParameterType = UnvalidatedType.NamedType.forParameter(interfac.getAdapterStruct().typeParameters[0])
+        val adapterType = UnvalidatedType.NamedType(interfac.adapterId.asRef(), interfac.getAdapterStruct().typeParameters.map { param -> UnvalidatedType.NamedType.forParameter(param) })
         val arguments = listOf(
             UnvalidatedArgument("data", dataParameterType, null),
             UnvalidatedArgument("adapter", adapterType, null)
         )
-        val instanceType = Type.NamedType(interfac.id.asRef(), interfac.typeParameters.map { param -> Type.NamedType.forParameter(param) })
+        val instanceType = UnvalidatedType.NamedType(interfac.id.asRef(), interfac.typeParameters.map { param -> UnvalidatedType.NamedType.forParameter(param) })
         val block = Block(listOf(),
                 Expression.NamedFunctionCall(
                         interfac.id.asRef(),
                         interfac.methods.map { method ->
-                            val adapterFunctionType = Type.FunctionType(listOf(dataParameterType) + method.functionType.argTypes,
+                            val adapterFunctionType = UnvalidatedType.FunctionType(listOf(dataParameterType) + method.functionType.argTypes,
                                     method.returnType)
                             Expression.ExpressionFunctionBinding(
                                     Expression.Follow(
@@ -129,7 +129,7 @@ private class InterfaceToStructConverter(private val context: RawContext) {
 
     private fun generateInstanceStruct(interfac: UnvalidatedInterface) {
         val members = interfac.methods.map { method ->
-            Member(method.name, method.functionType)
+            UnvalidatedMember(method.name, method.functionType)
         }
         val struct = UnvalidatedStruct(interfac.id, interfac.typeParameters,
                 members, null, interfac.annotations, null)

--- a/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/simplifyExpressions.kt
+++ b/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/simplifyExpressions.kt
@@ -19,7 +19,7 @@ private fun simplifyRequiresBlocks(oldStructs: List<UnvalidatedStruct>): List<Un
         oldStruct.copy(requires = if (requires == null) {
             null
         } else {
-            simplifyBlockExpressions(requires, oldStruct.members.map(Member::name))
+            simplifyBlockExpressions(requires, oldStruct.members.map(UnvalidatedMember::name))
         })
     }
 }

--- a/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/toSem0.kt
+++ b/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/toSem0.kt
@@ -47,7 +47,7 @@ private class Sem1To0Converter(val input: RawContext) {
         return S0Struct(id, struct.typeParameters, members, requires, annotations)
     }
 
-    private fun apply(member: Member): S0Member {
+    private fun apply(member: UnvalidatedMember): S0Member {
         val type = apply(member.type)
         return S0Member(member.name, type)
     }
@@ -72,19 +72,19 @@ private class Sem1To0Converter(val input: RawContext) {
         }
     }
 
-    private fun apply(type: Type): S0Type {
+    private fun apply(type: UnvalidatedType): S0Type {
         return when (type) {
-            Type.INTEGER -> S0Type.Integer
-            Type.NATURAL -> S0Type.Natural
-            Type.BOOLEAN -> S0Type.Boolean
-            is Type.List -> S0Type.List(apply(type.parameter))
-            is Type.Try -> S0Type.Try(apply(type.parameter))
-            is Type.FunctionType -> {
+            UnvalidatedType.INTEGER -> S0Type.Integer
+            UnvalidatedType.NATURAL -> S0Type.Natural
+            UnvalidatedType.BOOLEAN -> S0Type.Boolean
+            is UnvalidatedType.List -> S0Type.List(apply(type.parameter))
+            is UnvalidatedType.Try -> S0Type.Try(apply(type.parameter))
+            is UnvalidatedType.FunctionType -> {
                 val argTypes = type.argTypes.map(this::apply)
                 val outputType = apply(type.outputType)
                 S0Type.FunctionType(argTypes, outputType)
             }
-            is Type.NamedType -> {
+            is UnvalidatedType.NamedType -> {
                 val id = convertRef(type.ref)
                 val parameters = type.parameters.map(this::apply)
                 S0Type.NamedType(id, parameters)

--- a/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/variableNameConstrainer.kt
+++ b/kotlin/semlang-transforms/src/main/kotlin/net/semlang/transforms/variableNameConstrainer.kt
@@ -5,6 +5,7 @@ import net.semlang.api.*
 /**
  * Replaces the names of any variables or arguments in the context in a consistent way.
  */
+// TODO: Return an unvalidated module, and if possible, use an unvalidated module as input
 fun constrainVariableNames(module: ValidatedModule, renamingStrategy: VariableRenamingStrategy): ValidatedModule {
     val validatingStrategy = getValidatingStrategy(renamingStrategy)
     return ValidatedModule.create(module.id, module.nativeModuleVersion, renameWithinFunctions(module.ownFunctions, validatingStrategy), module.ownStructs,
@@ -96,7 +97,7 @@ private fun renameWithinExpression(expression: TypedExpression, renamingMap: Map
         }
         is TypedExpression.NamedFunctionCall -> {
             val arguments = expression.arguments.map { argument -> renameWithinExpression(argument, renamingMap) }
-            TypedExpression.NamedFunctionCall(expression.type, expression.functionRef, arguments, expression.chosenParameters)
+            TypedExpression.NamedFunctionCall(expression.type, expression.functionRef, expression.resolvedFunctionRef, arguments, expression.chosenParameters)
         }
         is TypedExpression.ExpressionFunctionCall -> {
             val functionExpression = renameWithinExpression(expression.functionExpression, renamingMap)
@@ -116,7 +117,7 @@ private fun renameWithinExpression(expression: TypedExpression, renamingMap: Map
         }
         is TypedExpression.NamedFunctionBinding -> {
             val bindings = expression.bindings.map { binding -> if (binding == null) null else renameWithinExpression(binding, renamingMap) }
-            TypedExpression.NamedFunctionBinding(expression.type, expression.functionRef, bindings, expression.chosenParameters)
+            TypedExpression.NamedFunctionBinding(expression.type, expression.functionRef, expression.resolvedFunctionRef, bindings, expression.chosenParameters)
         }
         is TypedExpression.ExpressionFunctionBinding -> {
             val functionExpression = renameWithinExpression(expression.functionExpression, renamingMap)


### PR DESCRIPTION
We may even want to instead use EntityResolutions (which store not just the ID and module ID but also the type of entity represented by the ID) in NamedTypes and NamedFunction* expressions. That can come later.