### PR TITLE
Handle parens for overriding operation precedence

### DIFF
--- a/antlr/antlr-sem2/src/main/antlr/sem2/antlr/Sem2Parser.g4
+++ b/antlr/antlr-sem2/src/main/antlr/sem2/antlr/Sem2Parser.g4
@@ -166,13 +166,21 @@ expression : IF LPAREN expression RPAREN block ELSE block
   | LBRACE optional_args statements return_statement RBRACE
   | expression DOT ID
   // NOTE: Higher expressions have higher precedence
+  | LPAREN expression TIMES expression RPAREN // * operator
   | expression TIMES expression // * operator
+  | LPAREN expression PLUS expression RPAREN // + operator
   | expression PLUS expression // + operator
+  | LPAREN expression HYPHEN expression RPAREN // - operator
   | expression HYPHEN expression // - operator
+  | LPAREN expression LESS_THAN expression RPAREN // < operator
   | expression LESS_THAN expression // < operator
+  | LPAREN expression GREATER_THAN expression RPAREN // > operator
   | expression GREATER_THAN expression // > operator
+  | LPAREN expression EQUALS expression RPAREN // == operator
   | expression EQUALS expression // == operator
+  | LPAREN expression NOT_EQUALS expression RPAREN // != operator
   | expression NOT_EQUALS expression // != operator
+  | LPAREN expression DOT_ASSIGN expression RPAREN // .= operator
   | expression DOT_ASSIGN expression // .= operator
   | ID
   ;

--- a/kotlin/sem2-parser/src/main/kotlin/sem2Parser.kt
+++ b/kotlin/sem2-parser/src/main/kotlin/sem2Parser.kt
@@ -367,13 +367,15 @@ private class ContextListener(val documentId: String) : Sem2ParserBaseListener()
                     return S2Expression.FunctionBinding(innerExpression!!, bindings, chosenParameters, locationOf(expression))
                 }
 
-                val chosenParameters = if (expression.LESS_THAN() != null) {
-                    parseCommaDelimitedTypes(expression.cd_types_nonempty())
-                } else {
-                    listOf()
+                if (expression.cd_expressions() != null) {
+                    val chosenParameters = if (expression.LESS_THAN() != null) {
+                        parseCommaDelimitedTypes(expression.cd_types_nonempty())
+                    } else {
+                        listOf()
+                    }
+                    val arguments = parseCommaDelimitedExpressions(expression.cd_expressions())
+                    return S2Expression.FunctionCall(innerExpression!!, arguments, chosenParameters, locationOf(expression))
                 }
-                val arguments = parseCommaDelimitedExpressions(expression.cd_expressions())
-                return S2Expression.FunctionCall(innerExpression!!, arguments, chosenParameters, locationOf(expression))
             }
 
             if (expression.LBRACKET() != null) {
@@ -757,8 +759,8 @@ private class ErrorListener(val documentId: String): ANTLRErrorListener {
         // Do nothing
     }
 
-    override fun reportContextSensitivity(recognizer: Parser?, dfa: DFA?, startIndex: Int, stopIndex: Int, prediction: Int, configs: ATNConfigSet?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    override fun reportContextSensitivity(recognizer: Parser, dfa: DFA?, startIndex: Int, stopIndex: Int, prediction: Int, configs: ATNConfigSet?) {
+        // Do nothing
     }
 
     override fun reportAttemptingFullContext(recognizer: Parser?, dfa: DFA?, startIndex: Int, stopIndex: Int, conflictingAlts: BitSet?, configs: ATNConfigSet?) {

--- a/sem2-corpus/precedenceParentheses1.sem
+++ b/sem2-corpus/precedenceParentheses1.sem
@@ -1,0 +1,5 @@
+@Test(["1", "2", "3"], "5")
+@Test(["3", "2", "1"], "9")
+function testPrecedence(a: Integer, b: Integer, c: Integer): Integer {
+  a * (b + c)
+}

--- a/sem2-corpus/precedenceParentheses2.sem
+++ b/sem2-corpus/precedenceParentheses2.sem
@@ -1,0 +1,5 @@
+@Test(["1", "2", "3"], "9")
+@Test(["3", "2", "1"], "5")
+function testPrecedence(a: Integer, b: Integer, c: Integer): Integer {
+  (a + b) * c
+}


### PR DESCRIPTION
The more general implementation of allowing `LPAREN expression RPAREN` as an expression was giving the parser problems.